### PR TITLE
fix(deploy): track Codex model catalog without .gitignore negation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,21 @@ uploads/
 # uv lockfile — not portable across PyPI proxies, generate locally with `uv lock`
 uv.lock
 
-# Codex CLI generated/cached files (only the bundled model catalog is tracked)
-.codex/*
-!.codex/databricks-models.json
+# Codex CLI generated/cached files. The bundled model catalog
+# (.codex/databricks-models.json) is tracked. Listed file-by-file rather
+# than `.codex/* + !.codex/databricks-models.json` because `databricks sync`
+# (and several other gitignore-honoring tools) doesn't respect the negation
+# pattern — that broke the deploy of databricks-models.json to the app
+# workspace, which Codex needs to start.
+.codex/config.toml
+.codex/.env
+.codex/AGENTS.md
+.codex/.personality_migration
+.codex/memories/
+.codex/tmp/
+.codex/sessions/
+.codex/cron/
+.codex/skills/
 
 # Codex skills are generated at runtime by setup_codex.py from .claude/skills/
 .agents/


### PR DESCRIPTION
## Priority

**P0 — Codex CLI is fully broken on deploy.** Every deployed app fails with `Error loading configuration: No such file or directory (os error 2)` the first time a user types `codex`. Only this one-file gitignore change is needed to restore Codex.

---

## Summary

Fix for #24. Codex CLI errors with `Error loading configuration: No such file or directory (os error 2)` on every deployed app because `databricks sync` doesn't honor `.gitignore` negation patterns — it was excluding `.codex/databricks-models.json` along with the rest of `.codex/`, so the deployed `~/.codex/` ended up without the model catalog that `config.toml` references.

## Change

Replaces in `.gitignore`:

```diff
-# Codex CLI generated/cached files (only the bundled model catalog is tracked)
-.codex/*
-!.codex/databricks-models.json
+# Codex CLI generated/cached files. The bundled model catalog
+# (.codex/databricks-models.json) is tracked. Listed file-by-file rather
+# than `.codex/* + !.codex/databricks-models.json` because `databricks sync`
+# (and several other gitignore-honoring tools) doesn't respect the negation
+# pattern — that broke the deploy of databricks-models.json to the app
+# workspace, which Codex needs to start.
+.codex/config.toml
+.codex/.env
+.codex/AGENTS.md
+.codex/.personality_migration
+.codex/memories/
+.codex/tmp/
+.codex/sessions/
+.codex/cron/
+.codex/skills/
```

## Verification

```bash
$ git check-ignore .codex/databricks-models.json && echo IGNORED || echo TRACKED
TRACKED                                                       # ✓
$ for f in .codex/config.toml .codex/.env .codex/AGENTS.md .codex/memories/x .codex/tmp/y; do
    git check-ignore "$f" >/dev/null && echo "$f → ignored" || echo "$f → leaked"
  done
.codex/config.toml → ignored                                   # ✓
.codex/.env → ignored                                          # ✓
.codex/AGENTS.md → ignored                                     # ✓
.codex/memories/x → ignored                                    # ✓
.codex/tmp/y → ignored                                         # ✓
```

## Test plan

- [ ] After merge, deploy a fresh CODA, confirm `~/.codex/databricks-models.json` exists in the running container.
- [ ] Run `codex` in the deployed terminal — should not error with "No such file or directory".

## Why not `.databricksignore` instead

`.databricksignore` is the alternative override path, but it's likely backed by the same gitignore parser — so a negation pattern there might also be skipped. Restructuring `.gitignore` to not need negation eliminates the ambiguity for *every* tool that reads it (databricks-cli, Docker, VSCode hover-ignored-decoration, etc.) rather than papering over it for just one.

Closes #24

This pull request and its description were written by Isaac.


---

## Test Evidence (verified on the live deployment 2026-05-06)

Captured from the user's deployed terminal at `https://coding-agents-7405613340366915.15.azure.databricksapps.com`:

```
$ ls -la ~/.codex/
-rw------- 1 app app  114 May  6 08:42 .env
-rw-r--r-- 1 app app    3 May  6 05:56 .personality_migration
-rw-r--r-- 1 app app 3678 May  6 05:53 AGENTS.md
-rw-r--r-- 1 app app  535 May  6 05:53 config.toml
drwxr-xr-x 2 app app 4096 May  6 05:56 memories
drwxr-xr-x 3 app app 4096 May  6 05:56 tmp

$ [ -f ~/.codex/databricks-models.json ] && echo OK || echo MISSING
MISSING

$ databricks workspace list /Workspace/Users/<owner>/apps/coding-agents/.codex/ -p daveok
Error: Path doesn't exist.
```

So the `.codex/` directory never made it into the synced workspace. `setup_codex.py` ran (other files in `~/.codex/` are present from setup) but `catalog_src.exists()` was False on the synced machine, silently skipping the copy.

After this fix lands, redeploy and verify with `[ -f ~/.codex/databricks-models.json ] && echo OK`.
