### PR TITLE
fix(claude): pick models from workspace's serving endpoints (GDS-aware)

### DIFF
--- a/setup_claude.py
+++ b/setup_claude.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from utils import ensure_https, get_gateway_host
+from utils import discover_serving_endpoints, ensure_https, get_gateway_host, pick_in_geo_model
 
 # Set HOME if not properly set
 if not os.environ.get("HOME") or os.environ["HOME"] == "/":
@@ -40,13 +40,46 @@ if token:
     else:
         settings = {}
 
+    # Discover models actually served at this workspace. The direct serving-
+    # endpoints list reflects Databricks Geo Designated Services policy — a
+    # workspace in AU only sees in-geo models, etc. Validating env-set defaults
+    # against this list avoids configuring Claude Code with a model the gateway
+    # claims to serve but the user's geo can't access.
+    available = discover_serving_endpoints(databricks_host, token)
+    if available:
+        print(f"Discovered {len(available)} READY serving endpoints at workspace")
+
+    requested_model = os.environ.get("ANTHROPIC_MODEL", "databricks-claude-opus-4-7")
+    active_model = pick_in_geo_model(
+        [requested_model, "databricks-claude-opus-4-6", "databricks-claude-sonnet-4-6"],
+        available,
+        fallback=requested_model,
+    )
+    opus_model = pick_in_geo_model(
+        ["databricks-claude-opus-4-7", "databricks-claude-opus-4-6"],
+        available,
+        fallback="databricks-claude-opus-4-7",
+    )
+    sonnet_model = pick_in_geo_model(
+        ["databricks-claude-sonnet-4-6", "databricks-claude-sonnet-4-5"],
+        available,
+        fallback="databricks-claude-sonnet-4-6",
+    )
+    haiku_model = pick_in_geo_model(
+        ["databricks-claude-haiku-4-5"],
+        available,
+        fallback="databricks-claude-haiku-4-5",
+    )
+    if available and active_model != requested_model:
+        print(f"ANTHROPIC_MODEL={requested_model} not served at this workspace, using {active_model}")
+
     settings.setdefault("env", {})
-    settings["env"]["ANTHROPIC_MODEL"] = os.environ.get("ANTHROPIC_MODEL", "databricks-claude-opus-4-7")
+    settings["env"]["ANTHROPIC_MODEL"] = active_model
     settings["env"]["ANTHROPIC_BASE_URL"] = anthropic_base_url
     settings["env"]["ANTHROPIC_AUTH_TOKEN"] = token
-    settings["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"] = "databricks-claude-opus-4-7"
-    settings["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"] = "databricks-claude-sonnet-4-6"
-    settings["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "databricks-claude-haiku-4-5"
+    settings["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"] = opus_model
+    settings["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"] = sonnet_model
+    settings["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = haiku_model
     settings["env"]["ANTHROPIC_CUSTOM_HEADERS"] = "x-databricks-use-coding-agent-mode: true"
     settings["env"]["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] = "1"
 

--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,8 @@ import re
 import subprocess
 from pathlib import Path
 
+import requests
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,7 +28,6 @@ def discover_serving_endpoints(host: str, token: str, timeout: float = 5.0) -> s
     if not host or not token:
         return set()
     try:
-        import requests
         resp = requests.get(
             f"{host}/api/2.0/serving-endpoints",
             headers={"Authorization": f"Bearer {token}"},

--- a/utils.py
+++ b/utils.py
@@ -2,10 +2,62 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 import subprocess
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def discover_serving_endpoints(host: str, token: str, timeout: float = 5.0) -> set[str]:
+    """Return the set of READY serving-endpoint names at the workspace.
+
+    The workspace's direct serving-endpoints list naturally reflects in-geo
+    model availability — Databricks Geo Designated Services restricts which
+    models are deployed to each region. Validating an env-set model against
+    this list is therefore equivalent to "is this model in the workspace's
+    geo / data-residency policy", without parsing GDS rules ourselves.
+
+    Returns an empty set on any failure (auth error, network blip, JSON parse,
+    etc.) — caller should treat empty as "discovery unavailable, keep defaults".
+    """
+    if not host or not token:
+        return set()
+    try:
+        import requests
+        resp = requests.get(
+            f"{host}/api/2.0/serving-endpoints",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        endpoints = resp.json().get("endpoints", [])
+        return {
+            ep["name"]
+            for ep in endpoints
+            if ep.get("name") and ep.get("state", {}).get("ready") == "READY"
+        }
+    except Exception as e:
+        logger.warning("Could not discover serving endpoints at %s: %s", host, e)
+        return set()
+
+
+def pick_in_geo_model(preferred: list[str], available: set[str], fallback: str) -> str:
+    """Pick the highest-priority preferred model that's actually served here.
+
+    `preferred` is the caller's degradation chain (e.g. opus-4-7 → opus-4-6).
+    Returns the first entry that's in `available`. If none match (or `available`
+    is empty because discovery failed), returns `fallback` — typically the
+    original env-set default. The user will see a clean ENDPOINT_NOT_FOUND
+    later if they actually try to use a missing model, rather than getting
+    silently downgraded to a different model tier.
+    """
+    for m in preferred:
+        if m in available:
+            return m
+    return fallback
 
 
 def get_npm_version(package_name):


### PR DESCRIPTION
## Priority

**P0 — Claude Code's Opus tier is broken on every non-US-geo workspace.** Workspaces in AU / EU / etc. serve `databricks-claude-opus-4-6` but not `opus-4-7`; `setup_claude.py` hardcodes the latter, so selecting Opus 404s. App-side workaround for the gateway-side issue tracked at #8.

---

## Summary

Fix for #26. Setup scripts had hardcoded model names that don't survive Geo Designated Services restrictions. This PR teaches `setup_claude.py` to query the workspace's `/api/2.0/serving-endpoints`, treat that list as the GDS-respecting "what's actually served here" oracle, and pick a working model in each tier.

## Changes

**`utils.py`** (+52, no logic changes elsewhere):
- `discover_serving_endpoints(host, token, timeout=5.0) -> set[str]` — returns READY endpoint names. Empty set on any failure (preserves caller's fallback behaviour).
- `pick_in_geo_model(preferred, available, fallback) -> str` — first preferred entry in `available`; else `fallback`.

**`setup_claude.py`** (+38/-5):
- Calls discovery once after host+token are known.
- Picks `ANTHROPIC_MODEL`, `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL` from the discovered list, walking a per-tier priority chain.
- Logs when an env-set request is substituted.
- Falls back to original env defaults if discovery returns empty (network failure, auth error, etc.) — behaviour matches main in failure modes.

## Test Evidence (verified on the live deployment 2026-05-06)

Smoke test against `daveok` (AU geo workspace):

```
$ python3 -c "from utils import discover_serving_endpoints, pick_in_geo_model; \
              avail = discover_serving_endpoints('https://adb-7405613340366915.15...', '$PAT'); \
              print(sorted(avail))"
['databricks-claude-haiku-4-5',
 'databricks-claude-opus-4-6',
 'databricks-claude-sonnet-4-5',
 'databricks-claude-sonnet-4-6',
 'databricks-gpt-oss-120b',
 'databricks-gpt-oss-20b',
 'databricks-qwen3-embedding-0-6b']

# pick_in_geo_model picks correctly:
Active model:  databricks-claude-opus-4-6   (env asked for opus-4-7, not served)
Opus tier:     databricks-claude-opus-4-6   (preferred opus-4-7 unavailable)
Sonnet tier:   databricks-claude-sonnet-4-6 (preferred, served)
Haiku tier:    databricks-claude-haiku-4-5  (only option, served)
```

Before: `/model` shows opus-4-7 → 404 on every Opus call. After: opus-4-6 used as Opus default → works.

## Test plan

- [ ] Deploy on a workspace WITH opus-4-7 (US geo) — confirm opus-4-7 still chosen (preferred winner).
- [ ] Deploy on a workspace WITHOUT opus-4-7 (AU/EU) — confirm opus-4-6 substituted, log line emitted.
- [ ] Disable network briefly during setup (or revoke the PAT temporarily) — confirm fallback to env-set defaults so setup doesn't fail outright.

## Out of scope

- `setup_codex.py`, `setup_hermes.py`, `setup_gemini.py`, `setup_opencode.py` need the same treatment. Will follow as separate single-agent PRs once this helper lands and the semantics are reviewed. Single-agent scope here keeps the helper introduction reviewable on its own.
- Doesn't fix #8 (the gateway-Beta picker showing x-geo models). That's gateway-side. This is the app-side workaround so users in non-US geos get a working Claude Code today.

Closes #26

This pull request and its description were written by Isaac.
