### PR TITLE
chore: drop the giant gitignore comment from #25 (post-merge nit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,12 +21,7 @@ uploads/
 # uv lockfile — not portable across PyPI proxies, generate locally with `uv lock`
 uv.lock
 
-# Codex CLI generated/cached files. The bundled model catalog
-# (.codex/databricks-models.json) is tracked. Listed file-by-file rather
-# than `.codex/* + !.codex/databricks-models.json` because `databricks sync`
-# (and several other gitignore-honoring tools) doesn't respect the negation
-# pattern — that broke the deploy of databricks-models.json to the app
-# workspace, which Codex needs to start.
+# Codex CLI generated/cached files (the bundled model catalog is tracked)
 .codex/config.toml
 .codex/.env
 .codex/AGENTS.md


### PR DESCRIPTION
## Summary

Follow-up to #25, addressing @mpkrass7's review suggestion that landed after #25 merged. Drops the migration-context comment block in `.gitignore` — context belongs in PR/issue history, not in the codebase.

## Why a separate PR

#25 merged at 2026-05-06T12:15 UTC, and Marshall's "LGTM, suggest removing the comment" came in at 12:12 — but the merge button got hit before the suggestion was applied. This is the cleanup.

## Test

```
$ git check-ignore .codex/databricks-models.json && echo IGNORED || echo TRACKED
TRACKED                                                       # ✓
$ for f in .codex/config.toml .codex/.env .codex/AGENTS.md .codex/memories/x .codex/tmp/y; do
    git check-ignore "$f" >/dev/null && echo "$f → ignored" || echo "$f → leaked"
  done
.codex/config.toml → ignored                                   # ✓
.codex/.env → ignored                                          # ✓
.codex/AGENTS.md → ignored                                     # ✓
.codex/memories/x → ignored                                    # ✓
.codex/tmp/y → ignored                                         # ✓
```

Same set of ignored files as before #25, just less narrative in the file.

This pull request and its description were written by Isaac.
