### PR TITLE
feat: ENABLE_<CLI> toggles + default-deny for Gemini, OpenCode, Hermes

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -14,9 +14,19 @@ env:
     value: databricks-claude-opus-4-6
   - name: HERMES_FALLBACK_MODEL
     value: databricks-claude-opus-4-6
-  # Set ENABLE_HERMES=false to skip Hermes Agent install. Other CLIs are unaffected.
-  - name: ENABLE_HERMES
+  # Per-CLI install toggle. Defaults reflect a "least-trusted code in the App
+  # container" stance: Claude Code (Anthropic) and Codex (OpenAI) ship from
+  # vendors with mature signing/SBOM/advisory pipelines and are enabled by
+  # default. Gemini, OpenCode, and Hermes are opt-in — set ENABLE_<CLI>=true
+  # to install them. Claude Code is the primary CLI and isn't toggleable here.
+  - name: ENABLE_CODEX
     value: "true"
+  - name: ENABLE_OPENCODE
+    value: "false"
+  - name: ENABLE_GEMINI
+    value: "false"
+  - name: ENABLE_HERMES
+    value: "false"
   - name: CLAUDE_CODE_DISABLE_AUTO_MEMORY
     value: 0
   - name: MAX_CONCURRENT_SESSIONS

--- a/setup_codex.py
+++ b/setup_codex.py
@@ -15,6 +15,11 @@ from pathlib import Path
 
 from utils import adapt_instructions_file, ensure_https, get_gateway_host, get_npm_version
 
+# Opt-out: allow operators to disable Codex bundling without removing the file.
+if os.environ.get("ENABLE_CODEX", "true").strip().lower() in ("false", "0", "no"):
+    print("ENABLE_CODEX=false — skipping Codex CLI setup")
+    raise SystemExit(0)
+
 # Set HOME if not properly set
 if not os.environ.get("HOME") or os.environ["HOME"] == "/":
     os.environ["HOME"] = "/app/python/source_code"

--- a/setup_gemini.py
+++ b/setup_gemini.py
@@ -17,6 +17,11 @@ from pathlib import Path
 
 from utils import adapt_instructions_file, ensure_https, get_gateway_host, get_npm_version
 
+# Opt-out: allow operators to disable Gemini bundling without removing the file.
+if os.environ.get("ENABLE_GEMINI", "true").strip().lower() in ("false", "0", "no"):
+    print("ENABLE_GEMINI=false — skipping Gemini CLI setup")
+    raise SystemExit(0)
+
 # Set HOME if not properly set
 if not os.environ.get("HOME") or os.environ["HOME"] == "/":
     os.environ["HOME"] = "/app/python/source_code"

--- a/setup_opencode.py
+++ b/setup_opencode.py
@@ -13,6 +13,11 @@ from pathlib import Path
 
 from utils import ensure_https, get_gateway_host, get_npm_version
 
+# Opt-out: allow operators to disable OpenCode bundling without removing the file.
+if os.environ.get("ENABLE_OPENCODE", "true").strip().lower() in ("false", "0", "no"):
+    print("ENABLE_OPENCODE=false — skipping OpenCode CLI setup")
+    raise SystemExit(0)
+
 # content-filter proxy local proxy — sanitizes empty content blocks before reaching Databricks
 # (see https://github.com/sst/opencode/issues/5028)
 CONTENT_FILTER_PROXY_URL = "http://127.0.0.1:4000"


### PR DESCRIPTION
## Summary

Introduce per-CLI install toggles (`ENABLE_CODEX`, `ENABLE_OPENCODE`, `ENABLE_GEMINI`, mirroring the existing `ENABLE_HERMES`), **and** default Gemini, OpenCode, and Hermes to OFF. A fresh CoDA deploy now ships with two CLIs running by default — Claude Code and Codex.

## Security posture rationale

The App container holds the rotated workspace PAT (`~/.databrickscfg`, written by `pat_rotator.py` every 10 min) and the user's repos under `~/projects/`. Any process that runs in there has effective full workspace access. That puts a higher bar on "what installs by default" than for local dev tools.

| CLI | Default | Why |
|---|---|---|
| Claude Code (Anthropic) | enabled (always-on; not toggleable) | Primary CLI; vendor with mature signing / SBOM / advisory disclosure |
| Codex (OpenAI) | enabled by default | Same supply-chain tier as Anthropic |
| Gemini (Google) | **opt-in** | Vendor has signing infra but lags upstream on SBOM/advisory pipelines for the CLI specifically |
| OpenCode (community/anomalyco fork) | **opt-in** | No equivalent enterprise supply-chain process |
| Hermes (Nous Research) | **opt-in** | No equivalent enterprise supply-chain process |

Operators who want the previous five-CLI experience flip the three toggles back to `"true"` in their own app.yaml override.

## Behavioural change for existing deploys

Operators upgrading to this version see Gemini/OpenCode/Hermes disappear unless they explicitly opt in. This is intentional — see rationale above — but worth calling out to reviewers as the substantive UX delta.

## Mechanics

- 4-line gate at the top of each `setup_*.py`: read env var, exit 0 if false. Exact pattern reuses `setup_hermes.py`'s existing structure.
- `app.yaml` documents all four toggles in one comment block.
- `setup_claude.py` is intentionally not gated — it bootstraps `~/projects/` and writes app-wide MCP config that the other CLIs reuse.

## Test plan

- [ ] Deploy to a workspace; confirm only Claude + Codex install steps run during boot
- [ ] In `app.yaml`, set `ENABLE_GEMINI=true`, redeploy; confirm Gemini installs
- [ ] Same for `ENABLE_OPENCODE=true` and `ENABLE_HERMES=true`
- [ ] Run `pytest tests/` — toggle-introduction tests should still pass
- [ ] Smoke-test the existing already-enabled flow: launch Claude Code and Codex from the App terminal, verify both authenticate against the workspace

## Follow-ups (out of scope for this PR)

- Flip the Python-level fallback defaults to `"false"` too, so a missing `app.yaml` also fails-closed. Currently each `setup_*.py` reads `os.environ.get("ENABLE_X", "true")` which is fail-open if app.yaml is absent.
- Add audit GH Action coverage for the still-enabled CLIs (Codex's `@openai/codex` is already in `dependency-audit.yml`; Claude Code is installed via curl so out of npm-audit scope).

This pull request and its description were written by Isaac.