### PR TITLE
fix(ui): default terminal to Dark mode so first-login PAT prompt is legible

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -537,10 +537,11 @@
       });
     }
 
-    // Resolve initial theme
+    // Resolve initial theme — default to Dark so onboarding ANSI prompts (e.g.
+    // the PAT setup screen) are legible. Users can still pick Light from the
+    // theme picker; their choice persists in localStorage.
     if (!currentThemeName || !themes[currentThemeName]) {
-      const prefersDark = !window.matchMedia('(prefers-color-scheme: light)').matches;
-      currentThemeName = prefersDark ? 'Dark' : 'Light';
+      currentThemeName = 'Dark';
     }
 
     // ── Theme Application ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Default the web terminal to **Dark** when no theme is saved in `localStorage`, instead of consulting OS `prefers-color-scheme`.
- Fixes the first-login PAT-injection prompt being unreadable on light backgrounds — the prompt is rendered with hardcoded ANSI codes (`\x1b[37m` white, `\x1b[90m` dark gray, `\x1b[4;36m` underlined cyan) that disappear on a light theme.
- Returning users keep their saved theme; the theme toggle and theme picker are unchanged.

## Why this fix

The PAT prompt is written to xterm.js *before* the user has a chance to interact with the theme toggle. xterm.js does not reliably repaint cells already in its buffer when `theme` is reassigned mid-session, so the toggle at the bottom didn't help even when users tried it. Defaulting to Dark removes the bug at source with a 2-line change.

We deliberately **didn't** rewrite the PAT prompt's ANSI codes — defaulting to Dark covers every realistic first-login path; a user who manually toggles to Light *before* configuring PAT is an edge-case-of-an-edge-case and can be handled later if it ever comes up.

## Test plan

- [ ] Open in an incognito window (empty `localStorage`) — page loads dark, PAT prompt is legible.
- [ ] On a macOS-light system (or DevTools → Rendering → emulate `prefers-color-scheme: light`), reload with empty `localStorage` — still loads dark.
- [ ] In DevTools, run `localStorage.setItem('terminal-theme-name', 'Light')` and reload — respects saved Light preference (no over-reach into existing user choices).
- [ ] Click the theme toggle — flips to Light, sun icon → moon icon. Toggle back returns to Dark.
- [ ] Smoke check: open new tab, run a shell command, open search bar (Cmd+F) — nothing visually broken in dark default.

This pull request and its description were written by Isaac.