### PR TITLE
fix(hermes): chmod 600 config.yaml + pin install URL to commit SHA

### DIFF
--- a/setup_hermes.py
+++ b/setup_hermes.py
@@ -50,7 +50,16 @@ hermes_bin = home / ".local" / "bin" / "hermes"
 # httpx, pyyaml, pydantic) cover chat + Databricks model serving. Not on PyPI,
 # so we install directly from GitHub. uv tool install handles venv + binary.
 # The mcp package is needed for HTTP transport (DeepWiki, Exa MCP servers).
-HERMES_PKG = "hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git"
+#
+# Pinned to a specific commit SHA (≥7 days old at the time of pinning) so a
+# force-push to NousResearch/hermes-agent's default branch can't ship code
+# into every CoDA container on the next cold start. Bump deliberately on
+# CoDA releases; do not auto-update.
+HERMES_PIN_SHA = "8e4f3ba4da5337e1ad674a876ac4fb8490f0b79c"  # 2026-05-08
+HERMES_PKG = (
+    "hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git"
+    f"@{HERMES_PIN_SHA}"
+)
 HERMES_EXTRA_DEPS = ["mcp>=1.2.0"]
 
 # 1. Install Hermes Agent (always, even without token).
@@ -193,6 +202,15 @@ if config_path.exists():
 
 if should_write:
     config_path.write_text("\n".join(lines))
+    # 0o600 — the file contains the plaintext PAT in `api_key:`. Without an
+    # explicit chmod the file inherits umask-derived perms (often 0o644 on
+    # container filesystems), making the token readable by any other process
+    # under the same UID. Matches setup_opencode.py's auth.json handling.
+    try:
+        config_path.chmod(0o600)
+    except OSError:
+        # Best effort — chmod can fail on some workspace filesystems.
+        pass
     print(f"Hermes config written: {config_path}")
 
 # 5. Adapt CLAUDE.md -> ~/.hermes/HERMES.md for first-run context


### PR DESCRIPTION
## Summary

Hotfix for two pre-existing security bugs in `setup_hermes.py` that affect every CoDA deploy from `main` today. Both were surfaced by the independent review of #38 (enterprise-proxy-registry) but they are **not gated on that feature** — they exist on main and are present in every container right now.

Landing them as a small standalone PR for easier review and faster turnaround than waiting for the larger feature work.

## F-05 — `~/.hermes/config.yaml` written without chmod 0o600

- **What's wrong:** `config_path.write_text(...)` inherits umask-derived permissions (typically `0o644` on container filesystems). The file contains the user's Databricks PAT in plaintext at `api_key:`. Any process running as the same UID inside the container can `cat ~/.hermes/config.yaml` and retrieve the token.
- **Fix:** explicit `config_path.chmod(0o600)` after the write. Best-effort (caught `OSError`) — mirrors the `setup_opencode.py:auth_path.chmod(0o600)` pattern that's already in place for OpenCode's credentials.
- **Threat scope:** in-container exfiltration. A malicious agent CLI install, a planted exfil tool from a compromised npm package, or any sibling process can read the PAT and use it against the workspace API for the token's remaining lifetime.

## F-06 — Hermes installed from unpinned HEAD of upstream git

- **What's wrong:** `HERMES_PKG = "hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git"` with no commit pin. Every fresh CoDA container pulls whatever `git rev-parse HEAD` returns at install time.
- **Fix:** pin to commit SHA `8e4f3ba4da5337e1ad674a876ac4fb8490f0b79c` (2026-05-08). That SHA is ≥7 days old at the time of pinning, matching the npm cooldown semantics we already apply to opencode/codex/gemini.
- **Threat scope:** a single force-push to NousResearch/hermes-agent's default branch — by a compromised maintainer account, a contributor with merge rights, or via gh org admin phish — runs arbitrary code in every CoDA container worldwide on next cold start. Low probability, unbounded blast radius.

## Operational note

The pin needs **deliberate rotation** on each CoDA release. Comment in the code says this explicitly. Don't auto-update — the whole point is that a CoDA-side reviewer signs off when bumping.

## Test plan

- [x] `import setup_hermes` locally — install runs from the pinned URL, no behavioural change in default flow
- [x] Verified on daveok via #38's Playwright e2e test (which has the same fixes):
  - `[PASS] F-05 Hermes config chmod 0o600`
  - `[PASS] F-06 Hermes installed (Hermes Agent v0.13.0 (2026.5.7))`
- [ ] Reviewer: smoke-deploy to your workspace and confirm `stat -c %a ~/.hermes/config.yaml` returns `600`

## Relation to #38

These two fixes are also included in #38 (enterprise-proxy-registry). Landing them separately because:

1. They're pre-existing exposures on main, independent of the enterprise feature
2. Small enough to review in 5 minutes
3. Won't block on the larger PR's review cycle

When #38 merges, this PR's changes will be a no-op (already present).

This pull request and its description were written by Isaac.