### PR TITLE
fix(security): owner-gate /api/configure-pat (hotfix)

### DIFF
--- a/app.py
+++ b/app.py
@@ -951,6 +951,18 @@ def pat_status():
 @app.route("/api/configure-pat", methods=["POST"])
 def configure_pat():
     """Accept a user-provided PAT, validate it, and start rotation."""
+    # Hotfix: only the resolved owner may (re-)configure the PAT. Without this,
+    # any workspace-SSO'd user who reaches the app can submit their own valid
+    # PAT and persistently impersonate the owner — every CLI call would then
+    # run under the submitter's identity. app_owner is set in initialize_app()
+    # before gunicorn binds, so it's reliably populated by request time on
+    # Databricks Apps; this guard short-circuits to "allow" only when owner
+    # resolution failed (matches the rest of the auth surface's behaviour).
+    if _is_databricks_apps() and app_owner:
+        if get_request_user() != app_owner:
+            logger.warning(f"Rejected configure-pat from non-owner {get_request_user()} (owner: {app_owner})")
+            return jsonify({"error": "Forbidden"}), 403
+
     data = request.json
     token = data.get("token", "").strip()
     if not token:

--- a/tests/test_auth_enforcement.py
+++ b/tests/test_auth_enforcement.py
@@ -115,6 +115,105 @@ class TestSessionEndpointAuth:
 
 
 # ---------------------------------------------------------------------------
+# 1b. /api/configure-pat MUST enforce owner check (hotfix)
+# ---------------------------------------------------------------------------
+
+class TestConfigurePatAuth:
+    """The PAT bootstrap endpoint is auth-exempt at the before_request gate
+    (intentionally — needed before the owner has set up). It MUST still gate
+    on owner once app_owner is resolved, otherwise any workspace-SSO'd user
+    can submit their own PAT and persistently impersonate the owner.
+    """
+
+    def test_configure_pat_denied_for_non_owner(self):
+        app_module = _get_app_module()
+        original_owner = app_module.app_owner
+        try:
+            app_module.app_owner = "owner@databricks.com"
+            client = _make_client(app_module)
+            with mock.patch.object(app_module, "_is_databricks_apps", return_value=True):
+                resp = client.post(
+                    "/api/configure-pat",
+                    json={"token": "dapi-attacker"},
+                    headers={"X-Forwarded-Email": "intruder@evil.com"},
+                )
+            assert resp.status_code == 403, (
+                f"POST /api/configure-pat should return 403 for non-owner, got {resp.status_code}"
+            )
+        finally:
+            app_module.app_owner = original_owner
+
+    def test_configure_pat_allowed_for_owner(self):
+        """Owner can still bootstrap. We don't run the rotator, just confirm
+        the auth guard doesn't return 403 — actual token validation is mocked
+        out separately and not in scope here."""
+        app_module = _get_app_module()
+        original_owner = app_module.app_owner
+        try:
+            app_module.app_owner = "owner@databricks.com"
+            client = _make_client(app_module)
+            with mock.patch.object(app_module, "_is_databricks_apps", return_value=True):
+                # Don't pass a token — we expect 400 ("Token required"), which
+                # proves the request got past the owner check.
+                resp = client.post(
+                    "/api/configure-pat",
+                    json={},
+                    headers={"X-Forwarded-Email": "owner@databricks.com"},
+                )
+            assert resp.status_code != 403, (
+                f"POST /api/configure-pat should not return 403 for owner, got {resp.status_code}"
+            )
+            assert resp.status_code == 400, (
+                f"Owner with empty body should get 400 'Token required', got {resp.status_code}"
+            )
+        finally:
+            app_module.app_owner = original_owner
+
+    def test_configure_pat_bootstrap_window_allowed(self):
+        """During the brief window where app_owner hasn't been resolved yet
+        (e.g., Apps API hiccup at startup), the endpoint must still accept
+        the request — otherwise the owner can never finish bootstrap.
+        This is intentional and documented in the in-handler comment."""
+        app_module = _get_app_module()
+        original_owner = app_module.app_owner
+        try:
+            app_module.app_owner = None  # unresolved
+            client = _make_client(app_module)
+            with mock.patch.object(app_module, "_is_databricks_apps", return_value=True):
+                resp = client.post(
+                    "/api/configure-pat",
+                    json={},
+                    headers={"X-Forwarded-Email": "anyone@databricks.com"},
+                )
+            # Should NOT be 403 — should fall through to "Token required" (400)
+            assert resp.status_code != 403, (
+                f"During bootstrap (app_owner unresolved), configure-pat should not 403, got {resp.status_code}"
+            )
+        finally:
+            app_module.app_owner = original_owner
+
+    def test_configure_pat_case_insensitive_for_owner(self):
+        """Owner email casing from the SSO header must match the lowercased
+        app_owner — same case-insensitive contract as the rest of auth."""
+        app_module = _get_app_module()
+        original_owner = app_module.app_owner
+        try:
+            app_module.app_owner = "owner@databricks.com"
+            client = _make_client(app_module)
+            with mock.patch.object(app_module, "_is_databricks_apps", return_value=True):
+                resp = client.post(
+                    "/api/configure-pat",
+                    json={},
+                    headers={"X-Forwarded-Email": "Owner@Databricks.COM"},
+                )
+            assert resp.status_code != 403, (
+                f"Mixed-case owner header should be accepted, got {resp.status_code}"
+            )
+        finally:
+            app_module.app_owner = original_owner
+
+
+# ---------------------------------------------------------------------------
 # 2. Case-insensitive email matching
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Hotfix for a PAT-impersonation vector discovered in pen testing 2026-05-17. The `/api/configure-pat` endpoint is intentionally exempt from the `before_request` auth gate (the owner needs to reach it before the app has any credentials), but without an in-handler owner check, any workspace-SSO'd user could submit their own valid PAT and persistently impersonate the owner.

## The vulnerability

`app.py:951` (pre-fix) — no idempotency or owner check. The endpoint:

1. Validates the submitted token via SCIM (passes — it's a real PAT)
2. Sets `os.environ['DATABRICKS_TOKEN'] = attacker_pat`
3. Mints new short-lived tokens via the rotator → all under attacker's identity
4. **Revokes the owner's previous PAT** as a side-effect of `revoke_bootstrap_token()`
5. Rewrites every CLI's credential file with attacker's PAT

From that point, every Claude/Codex/Gemini/OpenCode/Hermes/databricks CLI call made by the owner is audit-logged under the attacker's identity. The attacker can review their own PAT's audit history to reconstruct everything the owner did.

Exploitable at any time the app is reachable — not bootstrap-window only.

## The fix

One in-handler guard at the top of `configure_pat()`:

```python
if _is_databricks_apps() and app_owner:
    if get_request_user() != app_owner:
        return jsonify({"error": "Forbidden"}), 403
```

Reuses existing helpers (`_is_databricks_apps`, `get_request_user`, `app_owner`) — no new auth machinery introduced. Short-circuits to "allow" only when `app_owner` is unresolved at startup, matching the rest of the auth surface's bootstrap-window behaviour. Without this carve-out, no owner could ever finish bootstrap.

## Verification

**Unit (locked-in regression):** 4 new tests in `tests/test_auth_enforcement.py::TestConfigurePatAuth`:
- `test_configure_pat_denied_for_non_owner` → 403
- `test_configure_pat_allowed_for_owner` → 400 (Token required — past gate)
- `test_configure_pat_bootstrap_window_allowed` → not-403 when `app_owner=None`
- `test_configure_pat_case_insensitive_for_owner` → mixed-case header accepted

All pass. 231/231 total unit tests pass.

**E2E (against deployed daveok):** custom one-off probe (`.humantokens/configure_pat_e2e_probe.py`, not committed):
- [1/3] Owner POST empty body → HTTP 400 \`Token required\` ✓ (owner gate is open)
- [2/3] Forged \`X-Forwarded-Email\` + bogus PAT → HTTP 400 \`Invalid token\` ✓ (proves the Databricks Apps proxy strips client-supplied headers; identity is cookie-derived)
- [3/3] No-cookies POST → HTTP 401 ✓ (proxy enforces SSO)

## Why this is being merged as a hotfix

- Persistent (not bootstrap-window-only) impersonation primitive
- Discovered in pen test 2026-05-17; not addressed by PR #38 or PR #40
- Fix is 12 lines + 99 lines of test, single file each, surgical
- E2E-verified on live daveok deployment before merge

Sathish, requesting post-hoc review — flag anything you'd want refactored, will roll into the next normal PR.

## Test plan

- [x] Unit tests pass (231/231)
- [x] E2E probe against live deployment passes (3/3)
- [x] Hotfix-deployed daveok confirms behaviour through the real proxy stack
- [ ] Sathish post-hoc review

This pull request and its description were written by Isaac.