### PR TITLE
fix(security): idempotent /api/configure-pat (defence-in-depth follow-up to #42)

### DIFF
--- a/app.py
+++ b/app.py
@@ -963,6 +963,22 @@ def configure_pat():
             logger.warning(f"Rejected configure-pat from non-owner {get_request_user()} (owner: {app_owner})")
             return jsonify({"error": "Forbidden"}), 403
 
+    # Idempotency / defence-in-depth: bootstrap is single-shot. Once a PAT
+    # is configured and the rotator is alive, refuse re-submission. Without
+    # this, an XSS or session-hijack vector inside the owner's browser could
+    # drive a swap to an attacker-controlled PAT — the owner-gate above
+    # would let it through because the request truly does come from the
+    # owner's session. The expired-token escape hatch preserves the legitimate
+    # re-bootstrap path (rotator timed out while idle, owner needs to refresh).
+    if pat_rotator.token and not pat_rotator.is_token_expired:
+        logger.warning(
+            f"Rejected configure-pat: PAT already active "
+            f"(user={get_request_user()}, source={request.remote_addr})"
+        )
+        return jsonify({
+            "error": "PAT already configured. Restart the app to reconfigure."
+        }), 409
+
     data = request.json
     token = data.get("token", "").strip()
     if not token:

--- a/tests/test_auth_enforcement.py
+++ b/tests/test_auth_enforcement.py
@@ -212,6 +212,63 @@ class TestConfigurePatAuth:
         finally:
             app_module.app_owner = original_owner
 
+    # ---- Idempotency: defence-in-depth against XSS/session-hijack ----
+
+    def test_configure_pat_rejected_when_already_configured(self):
+        """When the rotator is alive with a fresh token, re-submission must
+        be refused with 409 — even from the legitimate owner. Defence-in-depth
+        against an attacker driving the owner's browser to swap PATs."""
+        app_module = _get_app_module()
+        original_owner = app_module.app_owner
+        try:
+            app_module.app_owner = "owner@databricks.com"
+            client = _make_client(app_module)
+            with mock.patch.object(app_module, "_is_databricks_apps", return_value=True), \
+                 mock.patch.object(type(app_module.pat_rotator), "token",
+                                    new_callable=mock.PropertyMock, return_value="dapi-active"), \
+                 mock.patch.object(type(app_module.pat_rotator), "is_token_expired",
+                                    new_callable=mock.PropertyMock, return_value=False):
+                resp = client.post(
+                    "/api/configure-pat",
+                    json={"token": "dapi-attempt-swap"},
+                    headers={"X-Forwarded-Email": "owner@databricks.com"},
+                )
+            assert resp.status_code == 409, (
+                f"Re-configure when rotator active should 409, got {resp.status_code}"
+            )
+            body = resp.get_json()
+            assert "already configured" in body.get("error", "").lower(), (
+                f"Error message should mention 'already configured', got: {body}"
+            )
+        finally:
+            app_module.app_owner = original_owner
+
+    def test_configure_pat_allowed_when_token_expired(self):
+        """Expired-token escape hatch: if the rotator timed out (long idle),
+        the owner must be able to re-bootstrap without restarting the app."""
+        app_module = _get_app_module()
+        original_owner = app_module.app_owner
+        try:
+            app_module.app_owner = "owner@databricks.com"
+            client = _make_client(app_module)
+            with mock.patch.object(app_module, "_is_databricks_apps", return_value=True), \
+                 mock.patch.object(type(app_module.pat_rotator), "token",
+                                    new_callable=mock.PropertyMock, return_value="dapi-stale"), \
+                 mock.patch.object(type(app_module.pat_rotator), "is_token_expired",
+                                    new_callable=mock.PropertyMock, return_value=True):
+                # Empty body → should reach "Token required" (400), proving
+                # we passed BOTH the owner gate and the idempotency check.
+                resp = client.post(
+                    "/api/configure-pat",
+                    json={},
+                    headers={"X-Forwarded-Email": "owner@databricks.com"},
+                )
+            assert resp.status_code == 400, (
+                f"Expired-PAT path should reach token-required check (400), got {resp.status_code}"
+            )
+        finally:
+            app_module.app_owner = original_owner
+
 
 # ---------------------------------------------------------------------------
 # 2. Case-insensitive email matching


### PR DESCRIPTION
## Summary

Defence-in-depth follow-up to the configure-pat hotfix in #42. Refuses re-configuration of the PAT once the rotator is alive with a valid token, returning **409 Conflict**.

## Why this exists

PR #42 closed the **impersonation vector** — a non-owner can no longer call \`/api/configure-pat\` and persistently impersonate the owner.

But the endpoint is still **non-idempotent for the legitimate owner**. Once a PAT is configured, anything that can drive the owner's authenticated browser session can swap PATs out from under the rotator:

- An XSS vector in the CoDA frontend (CSP is strict but \`'unsafe-inline'\` for scripts widens it)
- A malicious tab the owner has in another browser window
- Browser malware or a compromised extension
- An accidental double-submit during a network blip

The owner-gate from #42 cannot distinguish "the owner sent this" from "something running in the owner's browser sent this." This PR adds a state-based check that closes the swap vector regardless of who *appears* to be calling.

## The guard

```python
if pat_rotator.token and not pat_rotator.is_token_expired:
    logger.warning(...)
    return jsonify({"error": "PAT already configured. Restart the app to reconfigure."}), 409
```

| Scenario | Behaviour |
|---|---|
| Fresh app, no PAT yet | \`token\` is None → passes → normal bootstrap → 200 |
| PAT set but expired (rotator timed out while idle) | \`is_token_expired = True\` → passes → owner can re-bootstrap |
| PAT actively configured + rotator alive | → **409 Conflict**, log entry written |
| Frontend during normal use | Never calls configure-pat post-success (verified by grep) — no regression |

## Why 409, not 403

403 says "you're not allowed." 409 says "the resource is in a state that conflicts with this request." The owner DOES have permission — the issue is that bootstrap is single-shot. 409 is the semantically correct response.

## Tests

- \`test_configure_pat_rejected_when_already_configured\`: rotator alive → even owner gets 409
- \`test_configure_pat_allowed_when_token_expired\`: rotator timed out → owner can still bootstrap
- All 6 \`TestConfigurePatAuth\` cases pass; **233/233 unit tests pass**

## What this PR is NOT

- Not a primary security control — #42 remains the primary. This is defence-in-depth.
- Not a behavioural change for the frontend — \`createPane()\` only calls configure-pat in the "PAT not valid" branch, which by definition means \`is_token_expired\` is true, which the new guard explicitly permits.

## Test plan

- [x] 233/233 unit tests pass
- [x] Behavioural matrix above verified via unit tests
- [ ] Sathish post-hoc review

This pull request and its description were written by Isaac.