### PR TITLE
fix(deps): drop phantom starlette==1.0.0 pin, regenerate lockfile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -85,6 +85,7 @@ idna==3.13
     #   requests
 importlib-metadata==8.7.1
     # via
+    #   coda (pyproject.toml)
     #   mlflow-skinny
     #   opentelemetry-api
 itsdangerous==2.2.0
@@ -179,10 +180,11 @@ sqlparse==0.5.5
     # via mlflow-skinny
 sse-starlette==3.3.4
     # via mcp
-starlette==1.0.0
+starlette==0.52.1
     # via
     #   fastapi
     #   mcp
+    #   mlflow-skinny
     #   sse-starlette
 typing-extensions==4.15.0
     # via


### PR DESCRIPTION
## Summary
- App deploys on serverless workspaces have been failing at install time with:
  > Error installing packages. The conflict is caused by:
  > The user requested starlette==1.0.0 / fastapi 0.136.1 depends on starlette>=0.46.0 / mcp 1.27.1 depends on starlette>=0.27 / mlflow-skinny 3.12.0 depends on starlette<1 / no matching distributions available for starlette==1.0.0
- `requirements.txt` was pinning `starlette==1.0.0` — a version that doesn't exist on PyPI. The lockfile was last generated before #47 bumped `mlflow-skinny` to `3.12.0`, which added a new `starlette<1` cap on top of the conflict.
- Re-ran `uv pip compile pyproject.toml -o requirements.txt`. Resolver settles on `starlette==0.52.1`, which satisfies fastapi (≥0.46.0), mcp (≥0.27), and mlflow-skinny (<1).

## Diff
Three lines: `starlette==1.0.0` → `starlette==0.52.1`, plus mlflow-skinny added to starlette's `via` list (it now pulls starlette transitively under the new cap), plus pyproject.toml shows up under importlib-metadata's `via` list (we already have an explicit `<8.8` cap there).

## Test plan
- [x] `uv pip compile pyproject.toml -o requirements.txt` succeeds with `exclude-newer = "7 days"` (today: 2026-05-19)
- [x] `uv pip install -r requirements.txt` into a clean Python 3.11 venv installs all 67 packages with no conflicts
- [x] `uv pip check` reports "All installed packages are compatible"
- [x] Imports verified: `starlette`, `fastapi`, `mlflow`, `mcp`, `flask`, `flask_socketio`, `databricks.sdk` all load
- [x] Redeploy on a serverless workspace and confirm the app reaches `RUNNING`