### PR TITLE
chore(deps): cryptography 48 + 3 patches; cap protobuf<7 and starlette<1 (consolidates #34/#58/#61/#62; defers #59/#60)

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9  # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: Install audit tools
         run: pip install pip-audit==2.9.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9  # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: Run tests
         run: uv run pytest tests/ -v

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9  # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: Regenerate requirements.lock
         run: uv pip compile requirements.txt -o requirements.lock --generate-hashes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # Security floors — make CVE-driven minimums explicit so future resolves
     # can't silently downgrade. See PR description for advisory IDs.
     "gitpython>=3.1.49",
-    "python-multipart>=0.0.27",
+    "python-multipart>=0.0.29",
     # Upper bound is forced by our transitive ecosystem: both mlflow-skinny 3.11.x
     # AND opentelemetry-api 1.41.x cap importlib-metadata<8.8. Dependabot tried
     # to bump it to 9.0.0 (PR #3) and broke every deploy — explicit ceiling so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coda"
-version = "0.18.2"
+version = "0.18.3"
 description = "CoDA - Coding Agents on Databricks Apps"
 requires-python = ">=3.10"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,12 @@ dependencies = [
     # Explicit ceiling so the bot won't try again until databricks-sdk lifts
     # its <7.0 cap.
     "protobuf<7",
+    # Upper bound is forced by mlflow-skinny: 3.12.0 declares `starlette<1`.
+    # Dependabot tried to bump to starlette 1.0.0 (PR #59) — the pin worked
+    # with `uv pip sync` but `uv pip compile pyproject.toml` rejected it via
+    # mlflow-skinny's transitive cap. Explicit ceiling so the bot won't try
+    # again until mlflow-skinny lifts its <1 cap.
+    "starlette<1",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "databricks-sdk>=0.106.0",
     "mlflow-skinny==3.12.0",
     "requests",
-    "cryptography>=46.0.7",
+    "cryptography>=48.0.0",
     # Security floors — make CVE-driven minimums explicit so future resolves
     # can't silently downgrade. See PR description for advisory IDs.
     "gitpython>=3.1.49",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,12 @@ dependencies = [
     # to bump it to 9.0.0 (PR #3) and broke every deploy — explicit ceiling so
     # the bot won't try again until upstream widens its caps.
     "importlib-metadata<8.8",
+    # Upper bound is forced by databricks-sdk: 0.106.0 declares
+    # `protobuf!=5.26.*,...,<7.0,>=4.25.8`. Dependabot tried to bump to
+    # protobuf 7.34.1 (PR #60) and broke `pip install -r requirements.txt`.
+    # Explicit ceiling so the bot won't try again until databricks-sdk lifts
+    # its <7.0 cap.
+    "protobuf<7",
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -180,7 +180,7 @@ sqlparse==0.5.5
     # via mlflow-skinny
 sse-starlette==3.3.4
     # via mcp
-starlette==0.52.1
+starlette==1.0.0
     # via
     #   fastapi
     #   mcp

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,7 +120,7 @@ opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
 packaging==26.2
     # via mlflow-skinny
-protobuf==6.33.6
+protobuf==7.34.1
     # via
     #   databricks-sdk
     #   mlflow-skinny

--- a/requirements.txt
+++ b/requirements.txt
@@ -180,7 +180,7 @@ sqlparse==0.5.5
     # via mlflow-skinny
 sse-starlette==3.3.4
     # via mcp
-starlette==1.0.0
+starlette==0.52.1
     # via
     #   fastapi
     #   mcp

--- a/requirements.txt
+++ b/requirements.txt
@@ -149,7 +149,7 @@ python-dotenv==1.2.2
     #   pydantic-settings
 python-engineio==4.13.1
     # via python-socketio
-python-multipart==0.0.27
+python-multipart==0.0.29
     # via
     #   coda (pyproject.toml)
     #   mcp

--- a/requirements.txt
+++ b/requirements.txt
@@ -139,7 +139,7 @@ pydantic==2.13.3
     #   pydantic-settings
 pydantic-core==2.46.3
     # via pydantic
-pydantic-settings==2.14.0
+pydantic-settings==2.14.1
     # via mcp
 pyjwt==2.12.1
     # via mcp

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,7 +120,7 @@ opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
 packaging==26.2
     # via mlflow-skinny
-protobuf==7.34.1
+protobuf==6.33.6
     # via
     #   databricks-sdk
     #   mlflow-skinny

--- a/requirements.txt
+++ b/requirements.txt
@@ -122,6 +122,7 @@ packaging==26.2
     # via mlflow-skinny
 protobuf==6.33.6
     # via
+    #   coda (pyproject.toml)
     #   databricks-sdk
     #   mlflow-skinny
     #   opentelemetry-proto
@@ -182,6 +183,7 @@ sse-starlette==3.3.4
     # via mcp
 starlette==0.52.1
     # via
+    #   coda (pyproject.toml)
     #   fastapi
     #   mcp
     #   mlflow-skinny

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ click==8.3.3
     #   uvicorn
 cloudpickle==3.1.2
     # via mlflow-skinny
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   coda (pyproject.toml)
     #   google-auth


### PR DESCRIPTION
## Summary

Consolidates open dependabot PRs into one verified bump. Each lands as its own commit (cherry-picked from the original dependabot branches with authorship preserved) so any single bump can be reverted independently if a regression surfaces.

## Bumps in this PR (4 successful)

| Closes | Package | From → To | Type |
|---|---|---|---|
| #58 | cryptography | 46.0.7 → 48.0.0 | major ×2 (drops py3.8; project is ≥3.10) |
| #61 | python-multipart | 0.0.27 → 0.0.29 | patch |
| #62 | pydantic-settings | 2.14.0 → 2.14.1 | patch (transitive, via mcp) |
| #34 | astral-sh/setup-uv | 94527f2e → 37802adc | GitHub Action SHA pin |

`pyproject.toml` floors raised: `cryptography>=48.0.0`, `python-multipart>=0.0.29`.

## Deferred (2 dependabot proposals are poison pills)

Two dependabot PRs proposed major bumps that **conflict with our own pinned Databricks deps**. Both are cherry-picked → reverted → ceiling-capped in `pyproject.toml`, so dependabot stops re-proposing them until the upstream caps lift.

| PR | Bump | Conflict |
|----|------|----------|
| #60 | protobuf 6.33.6 → 7.34.1 | `databricks-sdk==0.106.0` declares `protobuf!=5.26.*,...,<7.0,>=4.25.8`. The bump errored `pip install -r requirements.txt` with a resolver conflict. |
| #59 | starlette 0.52.1 → 1.0.0 | `mlflow-skinny==3.12.0` declares `starlette<1`. The pin "worked" with `uv pip sync` (which trusts the file) but the canonical `uv pip compile pyproject.toml` silently reverted it. Confirmed via `--verbose` resolver trace. |

New ceilings added to `pyproject.toml` (matching the existing `importlib-metadata<8.8` pattern):
- `"protobuf<7"`
- `"starlette<1"`

Each carries an inline comment explaining the transitive cap, the dependabot PR number, and what would unblock re-proposing the bump.

Both PRs stay **open** for visibility (manual close with a "blocked on upstream cap" comment is the suggested follow-up).

## Verification (local)

Per-commit, with each bump installed via `uv pip sync requirements.txt`:

| Commit | Tests | Notes |
|---|---|---|
| pydantic-settings 2.14.1 | 347 pass, 1 npm flake (pre-existing) | transitive bump |
| python-multipart 0.0.29 | 347 pass, 1 npm flake | direct floor + lockfile |
| setup-uv SHA | n/a (CI-only action) | no runtime impact |
| cryptography 48.0.0 | 347 pass, 1 npm flake | `pat_rotator`, `content_filter_proxy`, `cli_auth` import + smoke OK |
| ~~starlette 1.0.0~~ | reverted | conflicts with `mlflow-skinny<1` cap |
| ~~protobuf 7.34.1~~ | reverted | conflicts with `databricks-sdk<7` cap |
| `protobuf<7` ceiling + regen | n/a (pyproject + requirements.txt metadata only) | prevents future dependabot proposals |
| `starlette<1` ceiling + regen | n/a (pyproject + requirements.txt metadata only) | prevents future dependabot proposals |

Final state: `requirements.txt` is **fully consistent with `pyproject.toml`** — verified by `uv pip compile pyproject.toml -o requirements.txt` producing no diff against the committed file. All 3 effective bumps (cryptography, python-multipart, pydantic-settings) report their new versions in the venv; full `setup_*.py` set AST-parses; `app`, `pat_rotator`, `content_filter_proxy`, `cli_auth`, `telemetry`, `app_state`, `utils` all import.

Tests deselected from the regression run (out-of-scope for dependency bumps):
- `tests/test_gateway_discovery.py::TestEndpointConstruction::*` — invokes `setup_claude.py` as a subprocess; hangs on the Claude Code curl installer in some environments (timeout-bound; affects local dev but not CI).
- `tests/test_npm_version_pinning.py::TestNpmVersionLive::test_resolves_real_package` — documented live-network flake, pre-existing baseline.

## Why one PR

Each of the dependabot PRs touched `requirements.txt`, so they conflict pairwise on merge — a multi-round dependabot rebase cycle every time one merges. Folding them into one verified branch gives the existing `update-lockfile.yml` workflow exactly one push to regenerate `requirements.lock` against.

`requirements.lock` is **not** updated in this PR — the existing GitHub Actions workflow (`.github/workflows/update-lockfile.yml`) will regenerate it on merge to `main`.

## Risk register

| Risk | Status |
|---|---|
| cryptography 48 breaks PAT JWT signing or content-filter-proxy TLS | smoke-imported both modules; tests green |
| protobuf 7 breaks MLflow trace serialization | **conflict surfaced at install time** — bump reverted, ceiling added |
| starlette 1.0 breaks MCP HTTP transport | **conflict surfaced at compile time** (mlflow-skinny cap) — bump reverted, ceiling added |
| `importlib-metadata<8.8` ceiling conflict | none observed; `uv pip sync` resolved cleanly each step |

## Test plan

- [x] Each commit individually verified against the unit-test baseline
- [x] Final cumulative smoke after all bumps applied
- [x] `uv pip compile pyproject.toml -o requirements.txt` produces no diff (file is canonical)
- [x] Protobuf + starlette install-time / compile-time conflicts caught; reverts + ceilings added
- [ ] CI regenerates `requirements.lock` post-merge (handled by `update-lockfile.yml`)
- [ ] Manual workspace deploy verification — recommended on a non-prod workspace before declaring this safe for production rollout

Closes #34
Closes #58
Closes #61
Closes #62
