### PR TITLE
chore(deps): bump urllib3/gitpython/idna for 4 Dependabot CVE alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,16 @@ dependencies = [
     "cryptography>=48.0.0",
     # Security floors — make CVE-driven minimums explicit so future resolves
     # can't silently downgrade. See PR description for advisory IDs.
-    "gitpython>=3.1.49",
+    "gitpython>=3.1.50",
     "python-multipart>=0.0.29",
+    # GHSA-qccp-gfcp-xxvc + GHSA-mf9v-mfxr-j63j — urllib3 < 2.7.0 leaks
+    # sensitive headers across proxied redirects and bypasses the
+    # decompression-bomb safeguard. urllib3 is transitive; pin a floor
+    # so dependency resolves don't drift back.
+    "urllib3>=2.7.0",
+    # GHSA-65pc-fj4g-8rjx — idna < 3.15 lets crafted inputs bypass the
+    # CVE-2024-3651 fix in idna.encode(). idna is transitive; pin a floor.
+    "idna>=3.15",
     # Upper bound is forced by our transitive ecosystem: both mlflow-skinny 3.11.x
     # AND opentelemetry-api 1.41.x cap importlib-metadata<8.8. Dependabot tried
     # to bump it to 9.0.0 (PR #3) and broke every deploy — explicit ceiling so

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ flask-socketio==5.6.1
     # via coda (pyproject.toml)
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.49
+gitpython==3.1.50
     # via
     #   coda (pyproject.toml)
     #   mlflow-skinny
@@ -78,8 +78,9 @@ httpx==0.28.1
     # via mcp
 httpx-sse==0.4.3
     # via mcp
-idna==3.13
+idna==3.16
     # via
+    #   coda (pyproject.toml)
     #   anyio
     #   httpx
     #   requests
@@ -208,8 +209,10 @@ typing-inspection==0.4.2
     #   mcp
     #   pydantic
     #   pydantic-settings
-urllib3==2.6.3
-    # via requests
+urllib3==2.7.0
+    # via
+    #   coda (pyproject.toml)
+    #   requests
 uvicorn==0.46.0
     # via
     #   mcp


### PR DESCRIPTION
## Summary

Patches all 4 open Dependabot alerts on `main`. Single dep-bump commit, no functional code changes.

| Alert | Severity | Package | Bump | Advisory |
|---|---|---|---|---|
| #6 | **HIGH** | `urllib3` | `2.6.3` → `2.7.0` | [GHSA-qccp-gfcp-xxvc](https://github.com/advisories/GHSA-qccp-gfcp-xxvc) — sensitive headers leak across origins on proxied low-level redirects |
| #5 | **HIGH** | `urllib3` | `2.6.3` → `2.7.0` | [GHSA-mf9v-mfxr-j63j](https://github.com/advisories/GHSA-mf9v-mfxr-j63j) — decompression-bomb safeguards bypassed in parts of the streaming API |
| #4 | **HIGH** | `gitpython` | `3.1.49` → `3.1.50` | [GHSA-mv93-w799-cj2w](https://github.com/advisories/GHSA-mv93-w799-cj2w) — newline injection in `config_writer()` bypasses CVE-2026-42215 patch; RCE via `core.hooksPath` |
| #7 | MEDIUM | `idna` | `3.13` → `3.16` | [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx) — crafted inputs to `idna.encode()` bypass the CVE-2024-3651 fix |

## Changes

- **`pyproject.toml`**: bumps the existing `gitpython` security floor and adds explicit floors for `urllib3` and `idna` (both are transitive via `requests` / `databricks-sdk`). This matches the existing convention in the "Security floors" block — explicit CVE-driven minimums so future resolves can't silently downgrade.
- **`requirements.txt`**: regenerated via `uv pip compile pyproject.toml -o requirements.txt`. Three patched versions land; `databricks-sdk` re-locks from `0.112.0` → `0.110.0` (the existing lockfile was resolved without the 7-day `exclude-newer` window; the re-resolve pulls back to the latest version ≥ 7 days old).

`idna` resolves to `3.16` rather than the spec-floor `3.15` because `3.16` is the latest version within the 7-day `exclude-newer` window. Both satisfy the floor and both contain the CVE-2024-3651-bypass fix.

`exclude-newer = "7 days"` is preserved unchanged — all three patches are old enough to land within the window.

## Test plan

- [x] `uv pip compile pyproject.toml -o requirements.txt` resolves cleanly
- [x] `uv lock` regenerates without conflict
- [x] `uv run pytest tests/ --ignore=tests/test_npm_version_pinning.py --ignore=tests/integration --ignore=tests/e2e` → **329 passed in 103.97s**
- [ ] Dependabot should auto-close the 4 alerts once this lands on `main`