### PR TITLE
fix(deps): install requests from PyPI instead of a git+https GitHub pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,3 @@ dev = [
 # This gives the community time to catch supply-chain issues before they land here.
 # Bump this date when you intentionally need a newer release.
 exclude-newer = "7 days"
-
-[tool.uv.sources]
-# Direct GitHub installs — workaround for Databricks internal PyPI proxy gaps.
-# Remove these once the proxy has current versions.
-requests = { git = "https://github.com/psf/requests", rev = "v2.33.0" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,7 +163,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests @ git+https://github.com/psf/requests@bc04dfd6dad4cb02cd92f5daa81eb562d280a761
+requests==2.33.0
     # via
     #   coda (pyproject.toml)
     #   databricks-sdk


### PR DESCRIPTION
## Summary

Deploys fail in network-restricted environments because `requests` is installed from a **GitHub git URL** instead of PyPI.

`pyproject.toml` carried:

```toml
[tool.uv.sources]
requests = { git = "https://github.com/psf/requests", rev = "v2.33.0" }
```

which bakes `requests @ git+https://github.com/psf/requests@<sha>` into `requirements.txt`. `databricks apps deploy` then `pip install`s from `requirements.txt`, and a `git+https` dependency requires the build environment to **`git clone` github.com** at install time. In a locked-down corporate network — only PyPI or an internal mirror reachable, no raw GitHub egress — that clone fails and the deploy errors out.

**Reported by a user behind such a network:** the app failed to deploy on `requests @ git+https://github.com/psf/requests@bc04dfd6dad4cb02cd92f5daa81eb562d280a761`.

## Root cause

The GitHub source was added in `a7b4113` as a stopgap for a transient *Databricks internal PyPI proxy* gap — per the in-file comment: *"Direct GitHub installs — workaround for Databricks internal PyPI proxy gaps. Remove these once the proxy has current versions."* `requests==2.33.0` is a normal PyPI release (PyPI currently serves 2.33.0, 2.33.1, 2.34.x), so the GitHub source is no longer needed and shouldn't be required for deployment in any environment.

## Change

- **`pyproject.toml`** — drop the `[tool.uv.sources]` `requests` git override. `requests` stays a normal dependency; the `exclude-newer` supply-chain guardrail is kept.
- **`requirements.txt`** — `requests @ git+https://…` → `requests==2.33.0` (same version, now from PyPI). Surgical one-line edit: `requests`' transitive deps (`urllib3`, `certifi`, `idna`, `charset-normalizer`) are already pinned, and editing only this line avoids an `exclude-newer`-driven re-pin of the rest of the lockfile.

Net diff: `pyproject.toml` −5 lines, `requirements.txt` 1 line.

## Test plan

- [ ] `pip install -r requirements.txt` resolves `requests==2.33.0` from PyPI with **no GitHub egress** required
- [ ] `databricks apps deploy` succeeds from a network-restricted environment (PyPI / internal mirror only)
- [ ] App runtime unaffected — same `requests` version (2.33.0)
