### PR TITLE
Route Codex through local proxy to survive PAT rotation

### DIFF
--- a/content_filter_proxy.py
+++ b/content_filter_proxy.py
@@ -31,6 +31,11 @@ UPSTREAM_BASE = os.environ.get("PROXY_UPSTREAM_BASE", "")
 LISTEN_HOST = os.environ.get("PROXY_HOST", "127.0.0.1")
 LISTEN_PORT = int(os.environ.get("PROXY_PORT", "4000"))
 
+# Passthrough mode: skip request/response munging, only inject fresh token.
+# Used by the Codex-facing proxy where the Responses-API payload shape
+# doesn't match the chat-completions sanitizers below.
+PASSTHROUGH = os.environ.get("PROXY_PASSTHROUGH", "").lower() == "true"
+
 # ---------------------------------------------------------------------------
 # Fresh token injection — survives PAT rotation
 # ---------------------------------------------------------------------------
@@ -522,23 +527,24 @@ class ProxyHandler(BaseHTTPRequestHandler):
         content_length = int(self.headers.get("Content-Length", 0))
         body = self.rfile.read(content_length)
 
-        log.info(f"POST {self.path} ({content_length} bytes)")
+        log.info(f"POST {self.path} ({content_length} bytes){' [passthrough]' if PASSTHROUGH else ''}")
 
-        # --- Sanitize request ---
-        try:
-            data = json.loads(body)
-            if "messages" in data:
-                before = len(data["messages"])
-                data["messages"] = sanitize_messages(data["messages"])
-                after = len(data["messages"])
-                if before != after:
-                    log.info(f"Messages: {before} -> {after}")
-            # Strip unsupported schema keys from tool definitions (all models)
-            data = sanitize_tool_schemas(data)
-            body = json.dumps(data).encode()
-        except (json.JSONDecodeError, KeyError) as e:
-            log.warning(f"Could not parse request body: {e}")
-            pass  # Forward as-is if not valid JSON
+        # --- Sanitize request (skipped in passthrough mode) ---
+        if not PASSTHROUGH:
+            try:
+                data = json.loads(body)
+                if "messages" in data:
+                    before = len(data["messages"])
+                    data["messages"] = sanitize_messages(data["messages"])
+                    after = len(data["messages"])
+                    if before != after:
+                        log.info(f"Messages: {before} -> {after}")
+                # Strip unsupported schema keys from tool definitions (all models)
+                data = sanitize_tool_schemas(data)
+                body = json.dumps(data).encode()
+            except (json.JSONDecodeError, KeyError) as e:
+                log.warning(f"Could not parse request body: {e}")
+                pass  # Forward as-is if not valid JSON
 
         # Build upstream URL
         upstream_url = UPSTREAM_BASE + self.path
@@ -578,13 +584,15 @@ class ProxyHandler(BaseHTTPRequestHandler):
 
             # --- Non-streaming response ---
             if not is_stream:
-                # Fix response
-                try:
-                    resp_data = resp.json()
-                    resp_data = fix_response_data(resp_data)
-                    resp_body = json.dumps(resp_data).encode()
-                except (json.JSONDecodeError, ValueError):
+                if PASSTHROUGH:
                     resp_body = resp.content
+                else:
+                    try:
+                        resp_data = resp.json()
+                        resp_data = fix_response_data(resp_data)
+                        resp_body = json.dumps(resp_data).encode()
+                    except (json.JSONDecodeError, ValueError):
+                        resp_body = resp.content
 
                 self.send_response(resp.status_code)
                 for key, value in resp.headers.items():
@@ -602,6 +610,15 @@ class ProxyHandler(BaseHTTPRequestHandler):
                     self.send_header(key, value)
             self.send_header("Transfer-Encoding", "chunked")
             self.end_headers()
+
+            if PASSTHROUGH:
+                # Forward raw SSE bytes — Responses-API events don't match the
+                # chat-completions SSEProcessor and shouldn't be re-serialized.
+                for chunk in resp.iter_content(chunk_size=4096):
+                    if chunk:
+                        self._send_chunk(chunk)
+                self._send_chunk(b"")
+                return
 
             processor = SSEProcessor()
 

--- a/setup_codex.py
+++ b/setup_codex.py
@@ -88,9 +88,14 @@ if gateway_host and not gateway_token:
     gateway_host = ""
 
 if gateway_host:
-    codex_base_url = f"{gateway_host}/openai/v1"
+    # Route through the local token-injection proxy (setup_proxy.py port 4001)
+    # so long-lived Codex sessions survive PAT rotation. The proxy re-reads
+    # the rotated token from ~/.databrickscfg on every request and overrides
+    # Authorization, so the OPENAI_API_KEY snapshotted at Codex startup no
+    # longer matters once a rotation happens.
+    codex_base_url = "http://127.0.0.1:4001/v1"
     auth_token = gateway_token
-    print(f"Using Databricks AI Gateway: {gateway_host}")
+    print(f"Using Databricks AI Gateway via local proxy: {gateway_host} -> 127.0.0.1:4001")
 else:
     codex_base_url = f"{host}/serving-endpoints"
     auth_token = token

--- a/setup_proxy.py
+++ b/setup_proxy.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
-"""Start the content-filter proxy between OpenCode and Databricks.
+"""Start localhost proxies that survive PAT rotation.
 
-Fixes known OpenCode bugs by sanitizing requests and responses:
-  - Empty text content blocks (OpenCode #5028)
-  - Orphaned tool_result blocks with no matching tool_use
-  - Databricks 'databricks-tool-call' name mangling
-  - Incorrect finish_reason on tool call responses
+Two instances run side by side:
+
+  - port 4000: OpenCode-facing proxy. Sanitizes chat-completions requests
+    (empty text blocks, orphaned tool_results, tool name mangling, finish_reason).
+  - port 4001: Codex-facing proxy in passthrough mode. Only re-injects the
+    fresh PAT from ~/.databrickscfg so long-lived Codex sessions don't go
+    stale when the rotator rolls the token.
 
 See docs/plans/2026-03-11-litellm-empty-content-blocks-design.md
 """
@@ -20,7 +22,8 @@ from urllib.error import URLError
 
 from utils import ensure_https, get_gateway_host
 
-PROXY_PORT = 4000
+OPENCODE_PROXY_PORT = 4000
+CODEX_PROXY_PORT = 4001
 PROXY_HOST = "127.0.0.1"
 HEALTH_TIMEOUT = 15
 HEALTH_POLL_INTERVAL = 0.5
@@ -30,27 +33,32 @@ if not os.environ.get("HOME") or os.environ["HOME"] == "/":
     os.environ["HOME"] = "/app/python/source_code"
 
 home = Path(os.environ["HOME"])
+proxy_script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "content_filter_proxy.py")
 
-# Kill any existing proxy on our port (more reliable than PID file)
-try:
-    result = subprocess.run(
-        ["fuser", "-k", f"{PROXY_PORT}/tcp"],
-        capture_output=True, text=True, timeout=5
-    )
-    if result.returncode == 0:
-        print(f"Killed previous process on port {PROXY_PORT}")
-        time.sleep(1)
-except (FileNotFoundError, subprocess.TimeoutExpired):
-    # fuser not available, try lsof
+
+def _kill_port(port: int) -> None:
+    """Kill any process holding `port` so we can rebind."""
     try:
         result = subprocess.run(
-            ["lsof", "-ti", f":{PROXY_PORT}"],
+            ["fuser", "-k", f"{port}/tcp"],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0:
+            print(f"Killed previous process on port {port}")
+            time.sleep(1)
+            return
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}"],
             capture_output=True, text=True, timeout=5
         )
         for pid in result.stdout.strip().split():
             try:
                 os.kill(int(pid), signal.SIGKILL)
-                print(f"Killed previous proxy (PID: {pid})")
+                print(f"Killed previous proxy on port {port} (PID: {pid})")
             except (ValueError, ProcessLookupError):
                 pass
         if result.stdout.strip():
@@ -58,9 +66,67 @@ except (FileNotFoundError, subprocess.TimeoutExpired):
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 
-# Clean up stale PID file
-pid_path = home / ".content-filter-proxy.pid"
-pid_path.unlink(missing_ok=True)
+
+def _start_proxy(port: int, upstream_base: str, passthrough: bool, label: str) -> bool:
+    """Spawn a content_filter_proxy instance and wait for it to come up."""
+    _kill_port(port)
+
+    log_path = home / f".content-filter-proxy-{label}.log"
+    pid_path = home / f".content-filter-proxy-{label}.pid"
+    pid_path.unlink(missing_ok=True)
+
+    print(f"Starting {label} proxy on {PROXY_HOST}:{port} -> {upstream_base}"
+          f"{' [passthrough]' if passthrough else ''}")
+
+    env = os.environ.copy()
+    env["PROXY_UPSTREAM_BASE"] = upstream_base
+    env["PROXY_HOST"] = PROXY_HOST
+    env["PROXY_PORT"] = str(port)
+    env["PROXY_PASSTHROUGH"] = "true" if passthrough else "false"
+
+    proc = subprocess.Popen(
+        [sys.executable, proxy_script],
+        stdout=open(log_path, "w"),
+        stderr=subprocess.STDOUT,
+        env=env,
+        start_new_session=True,
+    )
+    pid_path.write_text(str(proc.pid))
+    print(f"  {label} proxy started (PID: {proc.pid})")
+
+    health_url = f"http://{PROXY_HOST}:{port}/health"
+    start = time.time()
+    while time.time() - start < HEALTH_TIMEOUT:
+        try:
+            resp = urlopen(Request(health_url), timeout=2)
+            if resp.status == 200:
+                elapsed = time.time() - start
+                print(f"  {label} proxy ready ({elapsed:.1f}s)")
+                return True
+        except (URLError, OSError):
+            pass
+
+        if proc.poll() is not None:
+            print(f"  ERROR: {label} proxy exited with code {proc.returncode}")
+            try:
+                print(f"  Logs: {log_path.read_text()[:1000]}")
+            except Exception:
+                pass
+            return False
+
+        time.sleep(HEALTH_POLL_INTERVAL)
+
+    print(f"  WARN: {label} proxy health check timed out after {HEALTH_TIMEOUT}s")
+    try:
+        print(f"  Logs: {log_path.read_text()[:1000]}")
+    except Exception:
+        pass
+    return False
+
+
+# Legacy PID file from the single-proxy era — remove so it doesn't confuse
+# anyone looking for the OpenCode proxy.
+(home / ".content-filter-proxy.pid").unlink(missing_ok=True)
 
 # Databricks configuration
 gateway_host = get_gateway_host()
@@ -71,67 +137,21 @@ if not token:
     print("Warning: DATABRICKS_TOKEN not set, skipping proxy setup")
     sys.exit(0)
 
-# Determine the upstream base URL
+# OpenCode proxy: sanitizes chat-completions traffic
 if gateway_host:
-    upstream_base = f"{gateway_host}/mlflow/v1"
-    print(f"Content-filter proxy will forward to AI Gateway: {gateway_host}")
+    opencode_upstream = f"{gateway_host}/mlflow/v1"
 else:
-    upstream_base = f"{host}/serving-endpoints"
-    print(f"Content-filter proxy will forward to: {host}/serving-endpoints")
+    opencode_upstream = f"{host}/serving-endpoints"
+_start_proxy(OPENCODE_PROXY_PORT, opencode_upstream, passthrough=False, label="opencode")
 
-# Start proxy as a background process
-proxy_script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "content_filter_proxy.py")
-log_path = home / ".content-filter-proxy.log"
-print(f"Starting content-filter proxy on {PROXY_HOST}:{PROXY_PORT}...")
-
-env = os.environ.copy()
-env["PROXY_UPSTREAM_BASE"] = upstream_base
-env["PROXY_HOST"] = PROXY_HOST
-env["PROXY_PORT"] = str(PROXY_PORT)
-
-proc = subprocess.Popen(
-    [sys.executable, proxy_script],
-    stdout=open(log_path, "w"),
-    stderr=subprocess.STDOUT,
-    env=env,
-    start_new_session=True,
-)
-
-# Write PID file for cleanup
-pid_path = home / ".content-filter-proxy.pid"
-pid_path.write_text(str(proc.pid))
-print(f"Proxy started (PID: {proc.pid})")
-
-# Wait for health check
-health_url = f"http://{PROXY_HOST}:{PROXY_PORT}/health"
-start = time.time()
-ready = False
-
-while time.time() - start < HEALTH_TIMEOUT:
-    try:
-        resp = urlopen(Request(health_url), timeout=2)
-        if resp.status == 200:
-            ready = True
-            break
-    except (URLError, OSError):
-        pass
-
-    if proc.poll() is not None:
-        print(f"Error: Proxy exited with code {proc.returncode}")
-        try:
-            print(f"Logs: {log_path.read_text()[:1000]}")
-        except Exception:
-            pass
-        sys.exit(1)
-
-    time.sleep(HEALTH_POLL_INTERVAL)
-
-if ready:
-    elapsed = time.time() - start
-    print(f"Content-filter proxy ready on {PROXY_HOST}:{PROXY_PORT} ({elapsed:.1f}s)")
+# Codex proxy: token-injection only. Codex caches OPENAI_API_KEY at startup
+# and never re-reads ~/.codex/.env, so a long-lived TUI outlives the 15-min
+# rotated PAT. Routing through this proxy lets every request grab the fresh
+# token from ~/.databrickscfg via _get_fresh_token().
+# Path layout: Codex sends to /v1/responses against base_url=http://127.0.0.1:4001/v1,
+# proxy appends path to upstream → {gateway}/openai/v1/responses.
+if gateway_host:
+    _start_proxy(CODEX_PROXY_PORT, f"{gateway_host}/openai", passthrough=True, label="codex")
 else:
-    print(f"Warning: Proxy health check timed out after {HEALTH_TIMEOUT}s")
-    try:
-        print(f"Logs: {log_path.read_text()[:1000]}")
-    except Exception:
-        pass
+    print("No AI Gateway configured — skipping Codex proxy (direct serving-endpoints "
+          "has no /responses route)")


### PR DESCRIPTION
## Summary
- Codex CLI caches `OPENAI_API_KEY` from `~/.codex/.env` at startup, so long-lived TUI sessions hit `403 Invalid access token` after the 15-min rotated PAT expires (10-min rotation interval doesn't help — Codex never re-reads the file).
- Mirror the OpenCode fix: spawn a second `content_filter_proxy` instance on `:4001` in passthrough mode that re-injects the fresh PAT from `~/.databrickscfg` on every request via `_get_fresh_token()`.
- Point Codex's `base_url` at `http://127.0.0.1:4001/v1` so all Codex traffic flows through it. Token rotation becomes invisible to Codex.

## Changes
- `content_filter_proxy.py` — new `PROXY_PASSTHROUGH` env flag. When true: skip chat-completions request sanitization, skip `fix_response_data`, stream raw bytes for SSE (Responses-API event shapes don't match the chat-completions SSEProcessor). Auth-header injection still runs in both modes.
- `setup_proxy.py` — refactored into `_kill_port` / `_start_proxy` helpers. Spawns two instances:
  - `:4000` OpenCode-facing, sanitizer mode, upstream `…/mlflow/v1` (unchanged behavior)
  - `:4001` Codex-facing, passthrough mode, upstream `…/openai`
  - Per-instance log/PID files: `~/.content-filter-proxy-{opencode,codex}.{log,pid}`.
- `setup_codex.py` — `codex_base_url` flipped from `{gateway_host}/openai/v1` to `http://127.0.0.1:4001/v1`.

## Workaround for users currently blocked
`/quit` Codex and re-run `codex` — picks up the fresh token from `~/.codex/.env`. Will break again after ~15 min of continuous use until this PR lands.

## Test plan
- [ ] Deploy to a CoDA env, confirm both proxies come up healthy in startup logs
- [ ] Start a Codex session, leave idle ~20 min (past one rotation), send a prompt — should not 403
- [ ] Tail `~/.content-filter-proxy-codex.log` and confirm `[passthrough]` log lines on each request
- [ ] Run a prompt that triggers tool use — verify Responses-API SSE events stream through cleanly
- [ ] Confirm OpenCode still works unchanged (`:4000` proxy behavior is identical)
- [ ] Existing `test_cli_token_rotation.py` Codex tests still pass (didn't touch `cli_auth._update_codex()`)

This pull request and its description were written by Isaac.