### PR TITLE
DONT MERGE: Update default token lifetime and rotation interval

### DIFF
--- a/pat_rotator.py
+++ b/pat_rotator.py
@@ -18,8 +18,8 @@ from utils import ensure_https
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TOKEN_LIFETIME = 900        # 15 minutes
-DEFAULT_ROTATION_INTERVAL = 600     # 10 minutes
+DEFAULT_TOKEN_LIFETIME = 9000        # 150 minutes
+DEFAULT_ROTATION_INTERVAL = 6000    # 100 minutes
 
 
 class PATRotator:


### PR DESCRIPTION
Increased default token lifetime and rotation interval as a work around for JMS issue

## What does this PR do?

<!-- Brief description of your changes -->

## Testing

Please test your changes on dogfood before merging. 

- [ ] Deployed and tested on dogfood
- [ ] Added a screenshot to this PR
