### PR TITLE
fix: preserve UTF-8 output for attached coding agents

### DIFF
--- a/app.py
+++ b/app.py
@@ -276,6 +276,8 @@ def _build_terminal_shell_env(base_env: dict) -> dict:
     if not locale_value.replace("-", "").replace("_", "").lower().endswith("utf8"):
         shell_env["LANG"] = "C.UTF-8"
         shell_env["LC_ALL"] = "C.UTF-8"
+    if shell_env.get("ENABLE_SP_APIKEYHELPER", "").strip().lower() in ("true", "1", "yes"):
+        shell_env["DATABRICKS_CONFIG_PROFILE"] = "omnigents-host"
 
     # Always-strip fixed names
     for key in (
@@ -1438,6 +1440,18 @@ def pat_status():
     """Check if a valid, usable PAT is configured."""
     host = ensure_https(os.environ.get("DATABRICKS_HOST", ""))
     token = os.environ.get("DATABRICKS_TOKEN", "").strip()
+
+    if (
+        _omnigent_sp_creds
+        and os.environ.get("ENABLE_SP_APIKEYHELPER", "").strip().lower()
+        in ("true", "1", "yes")
+    ):
+        return jsonify({
+            "auth_mode": "sp_oauth",
+            "configured": True,
+            "valid": True,
+            "user": app_owner or "app-service-principal",
+        })
 
     if not token or pat_rotator.is_token_expired:
         # No token, or token lifetime exceeded (rotation stopped while no sessions)

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import hmac
+import codecs
 import pty
 import fcntl
 import struct
@@ -270,6 +271,11 @@ def _build_terminal_shell_env(base_env: dict) -> dict:
     """
     shell_env = base_env.copy()
     shell_env["TERM"] = "xterm-256color"
+    lc_all = shell_env.get("LC_ALL")
+    locale_value = lc_all if lc_all else shell_env.get("LANG", "")
+    if not locale_value.replace("-", "").replace("_", "").lower().endswith("utf8"):
+        shell_env["LANG"] = "C.UTF-8"
+        shell_env["LC_ALL"] = "C.UTF-8"
 
     # Always-strip fixed names
     for key in (
@@ -946,6 +952,22 @@ def read_pty_output(session_id, fd):
         return
     pid = session["pid"]
     session_lock = session["lock"]
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+
+    def emit_output(decoded):
+        if not decoded:
+            return
+        with session_lock:
+            # Buffer for HTTP polling fallback (AC-15)
+            session["output_buffer"].append(decoded)
+            session["last_poll_time"] = time.time()  # Keep session alive during WS output
+        # Push via WebSocket to the session room (AC-8)
+        try:
+            socketio.emit('terminal_output',
+                          {'session_id': session_id, 'output': decoded},
+                          room=session_id)
+        except Exception:
+            pass  # No WebSocket clients — HTTP polling handles it
 
     while True:
         with sessions_lock:
@@ -957,19 +979,9 @@ def read_pty_output(session_id, fd):
                 output = os.read(fd, 65536)
                 if not output:
                     # EOF — process exited
+                    emit_output(decoder.decode(b"", final=True))
                     break
-                decoded = output.decode(errors="replace")
-                with session_lock:
-                    # Buffer for HTTP polling fallback (AC-15)
-                    session["output_buffer"].append(decoded)
-                    session["last_poll_time"] = time.time()  # Keep session alive during WS output
-                # Push via WebSocket to the session room (AC-8)
-                try:
-                    socketio.emit('terminal_output',
-                                  {'session_id': session_id, 'output': decoded},
-                                  room=session_id)
-                except Exception:
-                    pass  # No WebSocket clients — HTTP polling handles it
+                emit_output(decoder.decode(output))
             else:
                 # select timed out — check if process is still alive
                 try:

--- a/content_filter_proxy.py
+++ b/content_filter_proxy.py
@@ -585,6 +585,13 @@ class SSEProcessor:
         return result
 
 
+def _decode_sse_line(raw_line: bytes | str) -> str:
+    """Decode SSE bytes as UTF-8 instead of requests' Latin-1 HTTP default."""
+    if isinstance(raw_line, bytes):
+        return raw_line.decode("utf-8")
+    return raw_line
+
+
 # ---------------------------------------------------------------------------
 # HTTP Server
 # ---------------------------------------------------------------------------
@@ -784,11 +791,11 @@ class ProxyHandler(BaseHTTPRequestHandler):
                     if ch.get("finish_reason"):
                         _stop_reason = ch["finish_reason"]
 
-            for raw_line in resp.iter_lines(decode_unicode=True):
+            for raw_line in resp.iter_lines(decode_unicode=False):
                 if raw_line is None:
                     continue
 
-                line = raw_line.strip() if isinstance(raw_line, str) else raw_line.decode().strip()
+                line = _decode_sse_line(raw_line).strip()
 
                 if not line:
                     # Blank line = event boundary, send it

--- a/content_filter_proxy.py
+++ b/content_filter_proxy.py
@@ -26,7 +26,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from socketserver import ThreadingMixIn
 
 import requests
-from token_helper import resolve_databricks_token
+from token_helper import resolve_databricks_token, resolve_sp_oauth_token
 
 UPSTREAM_BASE = os.environ.get("PROXY_UPSTREAM_BASE", "")
 LISTEN_HOST = os.environ.get("PROXY_HOST", "127.0.0.1")
@@ -98,7 +98,7 @@ def _get_fresh_token() -> str | None:
     if cache_hot:
         return _TOKEN_CACHE["token"]
 
-    token = resolve_databricks_token()
+    token = resolve_sp_oauth_token()
     if token:
         _TOKEN_CACHE["token"] = token
         _TOKEN_CACHE["read_at"] = now
@@ -116,6 +116,13 @@ def _get_fresh_token() -> str | None:
             return token
     except Exception as e:
         log.warning(f"Could not read fresh token from {_DATABRICKSCFG_PATH}: {e}")
+
+    token = resolve_databricks_token()
+    if token:
+        _TOKEN_CACHE["token"] = token
+        _TOKEN_CACHE["read_at"] = now
+        _TOKEN_CACHE["mtime"] = mtime
+        return token
 
     return _TOKEN_CACHE.get("token")  # stale is better than nothing
 

--- a/content_filter_proxy.py
+++ b/content_filter_proxy.py
@@ -26,6 +26,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from socketserver import ThreadingMixIn
 
 import requests
+from token_helper import resolve_databricks_token
 
 UPSTREAM_BASE = os.environ.get("PROXY_UPSTREAM_BASE", "")
 LISTEN_HOST = os.environ.get("PROXY_HOST", "127.0.0.1")
@@ -96,6 +97,13 @@ def _get_fresh_token() -> str | None:
     )
     if cache_hot:
         return _TOKEN_CACHE["token"]
+
+    token = resolve_databricks_token()
+    if token:
+        _TOKEN_CACHE["token"] = token
+        _TOKEN_CACHE["read_at"] = now
+        _TOKEN_CACHE["mtime"] = mtime
+        return token
 
     try:
         config = configparser.ConfigParser()

--- a/setup_opencode.py
+++ b/setup_opencode.py
@@ -22,6 +22,7 @@ from utils import (
     pick_in_geo_model,
 )
 from enterprise_config import npm_env
+from token_helper import resolve_databricks_token
 
 # Opt-out: allow operators to disable OpenCode bundling without removing the file.
 if os.environ.get("ENABLE_OPENCODE", "true").strip().lower() in ("false", "0", "no"):
@@ -39,7 +40,7 @@ if not os.environ.get("HOME") or os.environ["HOME"] == "/":
 home = Path(os.environ["HOME"])
 
 host = os.environ.get("DATABRICKS_HOST", "")
-token = os.environ.get("DATABRICKS_TOKEN", "")
+token = resolve_databricks_token() or ""
 anthropic_model = os.environ.get("ANTHROPIC_MODEL", "databricks-claude-opus-4-8")
 
 # 1. Install OpenCode CLI into ~/.local/bin (always, even without token)
@@ -107,7 +108,7 @@ if not host or not token:
 host = ensure_https(host.rstrip("/"))
 
 gateway_host = get_gateway_host()
-gateway_token = os.environ.get("DATABRICKS_TOKEN", "") if gateway_host else ""
+gateway_token = token if gateway_host else ""
 if gateway_host and not gateway_token:
     print("Warning: AI Gateway resolved but DATABRICKS_TOKEN missing, falling back to DATABRICKS_HOST")
     gateway_host = ""

--- a/setup_proxy.py
+++ b/setup_proxy.py
@@ -19,6 +19,7 @@ from urllib.request import urlopen, Request
 from urllib.error import URLError
 
 from utils import ensure_https, get_gateway_host
+from token_helper import resolve_databricks_token
 
 # The proxy exists solely for OpenCode — skip it when OpenCode is disabled.
 if os.environ.get("ENABLE_OPENCODE", "true").strip().lower() in ("false", "0", "no"):
@@ -70,10 +71,10 @@ pid_path.unlink(missing_ok=True)
 # Databricks configuration
 gateway_host = get_gateway_host()
 host = ensure_https(os.environ.get("DATABRICKS_HOST", "").rstrip("/"))
-token = os.environ.get("DATABRICKS_TOKEN", "")
+token = resolve_databricks_token() or ""
 
 if not token:
-    print("Warning: DATABRICKS_TOKEN not set, skipping proxy setup")
+    print("Warning: no SP OAuth or PAT token available, skipping proxy setup")
     sys.exit(0)
 
 # Determine the upstream base URL
@@ -90,6 +91,7 @@ log_path = home / ".content-filter-proxy.log"
 print(f"Starting content-filter proxy on {PROXY_HOST}:{PROXY_PORT}...")
 
 env = os.environ.copy()
+env["DATABRICKS_TOKEN"] = token
 env["PROXY_UPSTREAM_BASE"] = upstream_base
 env["PROXY_HOST"] = PROXY_HOST
 env["PROXY_PORT"] = str(PROXY_PORT)

--- a/tests/test_apikey_helper.py
+++ b/tests/test_apikey_helper.py
@@ -16,6 +16,7 @@ import re
 import types
 
 import pytest
+import token_helper
 
 
 def _extract_helper_source() -> str:
@@ -33,6 +34,16 @@ def _load_helper_module():
 
 
 class TestSpBranch:
+    def test_runtime_resolver_prefers_loopback_broker(self, monkeypatch):
+        monkeypatch.setenv("CODA_SP_TOKEN_BROKER_URL", "http://127.0.0.1:4010/token")
+        monkeypatch.setattr(
+            token_helper,
+            "urlopen",
+            lambda *_a, **_k: _BrokerResponse(b"broker-token"),
+        )
+
+        assert token_helper.resolve_sp_oauth_token() == "broker-token"
+
     def test_sdk_mint_strips_bearer_prefix(self, monkeypatch):
         """SP path returns the raw token with 'Bearer ' stripped."""
         mod = _load_helper_module()
@@ -117,3 +128,17 @@ class TestMainOutput:
         with pytest.raises(SystemExit) as e:
             mod.main()
         assert e.value.code == 1
+
+
+class _BrokerResponse:
+    def __init__(self, body):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self):
+        return self.body

--- a/tests/test_content_filter_proxy.py
+++ b/tests/test_content_filter_proxy.py
@@ -19,6 +19,7 @@ def tmp_cfg(tmp_path, monkeypatch):
     import content_filter_proxy as cfp
     monkeypatch.setattr(cfp, "_DATABRICKSCFG_PATH", str(cfg))
     monkeypatch.setattr(cfp, "_TOKEN_CACHE", {"token": None, "read_at": 0.0, "mtime": 0.0})
+    monkeypatch.setattr(cfp, "resolve_databricks_token", lambda: None)
     return cfg
 
 
@@ -74,4 +75,14 @@ class TestFreshTokenCacheInvalidation:
         missing = tmp_path / "does-not-exist"
         monkeypatch.setattr(cfp, "_DATABRICKSCFG_PATH", str(missing))
         monkeypatch.setattr(cfp, "_TOKEN_CACHE", {"token": None, "read_at": 0.0, "mtime": 0.0})
+        monkeypatch.setattr(cfp, "resolve_databricks_token", lambda: None)
         assert cfp._get_fresh_token() is None
+
+    def test_uses_sp_oauth_when_default_pat_is_missing(self, tmp_path, monkeypatch):
+        import content_filter_proxy as cfp
+        missing = tmp_path / "does-not-exist"
+        monkeypatch.setattr(cfp, "_DATABRICKSCFG_PATH", str(missing))
+        monkeypatch.setattr(cfp, "_TOKEN_CACHE", {"token": None, "read_at": 0.0, "mtime": 0.0})
+        monkeypatch.setattr(cfp, "resolve_databricks_token", lambda: "sp-oauth-token")
+
+        assert cfp._get_fresh_token() == "sp-oauth-token"

--- a/tests/test_content_filter_proxy.py
+++ b/tests/test_content_filter_proxy.py
@@ -19,6 +19,7 @@ def tmp_cfg(tmp_path, monkeypatch):
     import content_filter_proxy as cfp
     monkeypatch.setattr(cfp, "_DATABRICKSCFG_PATH", str(cfg))
     monkeypatch.setattr(cfp, "_TOKEN_CACHE", {"token": None, "read_at": 0.0, "mtime": 0.0})
+    monkeypatch.setattr(cfp, "resolve_sp_oauth_token", lambda: None)
     monkeypatch.setattr(cfp, "resolve_databricks_token", lambda: None)
     return cfg
 
@@ -28,6 +29,16 @@ def _write_cfg(path, token):
 
 
 class TestFreshTokenCacheInvalidation:
+    def test_rotated_pat_beats_stale_proxy_env_token(self, tmp_cfg, monkeypatch):
+        from content_filter_proxy import _get_fresh_token
+        _write_cfg(tmp_cfg, "dapi-rotated")
+        monkeypatch.setattr(
+            "content_filter_proxy.resolve_databricks_token",
+            lambda: "dapi-startup",
+        )
+
+        assert _get_fresh_token() == "dapi-rotated"
+
     def test_cache_invalidates_on_mtime_change(self, tmp_cfg):
         from content_filter_proxy import _get_fresh_token
         _write_cfg(tmp_cfg, "dapi-old")

--- a/tests/test_content_filter_proxy.py
+++ b/tests/test_content_filter_proxy.py
@@ -86,3 +86,10 @@ class TestFreshTokenCacheInvalidation:
         monkeypatch.setattr(cfp, "resolve_databricks_token", lambda: "sp-oauth-token")
 
         assert cfp._get_fresh_token() == "sp-oauth-token"
+
+
+def test_sse_line_decodes_literal_utf8_without_latin1_mojibake():
+    from content_filter_proxy import _decode_sse_line
+
+    raw = 'data: {"text":"✓ café → │ ─ 😀"}'.encode("utf-8")
+    assert _decode_sse_line(raw) == 'data: {"text":"✓ café → │ ─ 😀"}'

--- a/tests/test_mlflow_tracing.py
+++ b/tests/test_mlflow_tracing.py
@@ -23,6 +23,7 @@ def run_setup_mlflow(tmp_path, env_overrides=None):
         "HOME": str(tmp_path),
         "DATABRICKS_HOST": "https://test.cloud.databricks.com",
         "DATABRICKS_TOKEN": "dapi_test_token",
+        "CODA_VENV_PYTHON": "/usr/bin/true",
         "PATH": os.environ.get("PATH", ""),
     }
     if env_overrides:

--- a/tests/test_pat_rotation_integration.py
+++ b/tests/test_pat_rotation_integration.py
@@ -36,6 +36,33 @@ class TestPATStatusEndpoint:
             if original:
                 os.environ["DATABRICKS_TOKEN"] = original
 
+    def test_sp_apikeyhelper_is_valid_without_pat(self):
+        with mock.patch("app.initialize_app"):
+            import app as app_module
+            app_module.app.config["TESTING"] = True
+            client = app_module.app.test_client()
+
+        original_token = os.environ.pop("DATABRICKS_TOKEN", None)
+        original_creds = app_module._omnigent_sp_creds
+        original_owner = app_module.app_owner
+        try:
+            os.environ["ENABLE_SP_APIKEYHELPER"] = "true"
+            app_module._omnigent_sp_creds = {"client_id": "app-sp"}
+            app_module.app_owner = "owner@example.com"
+            resp = client.get("/api/pat-status")
+            assert resp.get_json() == {
+                "auth_mode": "sp_oauth",
+                "configured": True,
+                "valid": True,
+                "user": "owner@example.com",
+            }
+        finally:
+            os.environ.pop("ENABLE_SP_APIKEYHELPER", None)
+            app_module._omnigent_sp_creds = original_creds
+            app_module.app_owner = original_owner
+            if original_token:
+                os.environ["DATABRICKS_TOKEN"] = original_token
+
     def test_configure_pat_empty_token(self):
         with mock.patch("app.initialize_app"):
             import app as app_module

--- a/tests/test_session_detach.py
+++ b/tests/test_session_detach.py
@@ -255,3 +255,46 @@ class TestEOFCleanup:
 
         with self.app_module.sessions_lock:
             assert session_id not in self.app_module.sessions
+
+    def test_utf8_character_split_across_reads_is_emitted_intact(self, monkeypatch):
+        session_id = "sess-utf8-split"
+        glyph = "│"
+        first, second = glyph.encode("utf-8")[:1], glyph.encode("utf-8")[1:]
+        chunks = iter((first, second, b""))
+        emitted = []
+
+        with self.app_module.sessions_lock:
+            self.app_module.sessions[session_id] = {
+                "pid": 123,
+                "master_fd": 456,
+                "output_buffer": deque(maxlen=1000),
+                "lock": threading.Lock(),
+                "last_poll_time": time.time(),
+                "created_at": time.time(),
+            }
+
+        monkeypatch.setattr(
+            self.app_module.select,
+            "select",
+            lambda *_args: ([456], [], []),
+        )
+        monkeypatch.setattr(self.app_module.os, "read", lambda *_args: next(chunks))
+        monkeypatch.setattr(
+            self.app_module.socketio,
+            "emit",
+            lambda event, data=None, **_kwargs: emitted.append((event, data)),
+        )
+        monkeypatch.setattr(
+            self.app_module,
+            "terminate_session",
+            lambda *_args: None,
+        )
+
+        self.app_module.read_pty_output(session_id, 456)
+
+        terminal_text = "".join(
+            data["output"]
+            for event, data in emitted
+            if event == "terminal_output"
+        )
+        assert terminal_text == glyph

--- a/tests/test_terminal_env_strip.py
+++ b/tests/test_terminal_env_strip.py
@@ -94,6 +94,11 @@ class TestTerminalEnvStrip:
         assert env["LANG"] == "en_AU.UTF-8"
         assert "LC_ALL" not in env
 
+    def test_sp_apikeyhelper_selects_oauth_profile(self):
+        build = _build_terminal_shell_env()
+        env = build({"HOME": "/app", "ENABLE_SP_APIKEYHELPER": "true"})
+        assert env["DATABRICKS_CONFIG_PROFILE"] == "omnigents-host"
+
     def test_preserves_unrelated_env(self):
         """Other env vars (PATH, USER, custom workspace vars) pass through."""
         build = _build_terminal_shell_env()

--- a/tests/test_terminal_env_strip.py
+++ b/tests/test_terminal_env_strip.py
@@ -82,6 +82,18 @@ class TestTerminalEnvStrip:
         env = build({"HOME": "/app"})
         assert env["TERM"] == "xterm-256color"
 
+    def test_sets_utf8_locale_when_missing(self):
+        build = _build_terminal_shell_env()
+        env = build({"HOME": "/app"})
+        assert env["LANG"] == "C.UTF-8"
+        assert env["LC_ALL"] == "C.UTF-8"
+
+    def test_preserves_existing_utf8_locale(self):
+        build = _build_terminal_shell_env()
+        env = build({"HOME": "/app", "LANG": "en_AU.UTF-8"})
+        assert env["LANG"] == "en_AU.UTF-8"
+        assert "LC_ALL" not in env
+
     def test_preserves_unrelated_env(self):
         """Other env vars (PATH, USER, custom workspace vars) pass through."""
         build = _build_terminal_shell_env()

--- a/token_helper.py
+++ b/token_helper.py
@@ -18,6 +18,7 @@ import configparser
 import os
 import sys
 from pathlib import Path
+from urllib.request import urlopen
 
 # The SP OAuth profile the Omnigent host writes (auth_type=oauth-m2m). Kept in
 # sync with omnigents_host._HOST_PROFILE and setup_claude._SP_PROFILE.
@@ -26,6 +27,15 @@ SP_PROFILE = "omnigents-host"
 
 def resolve_sp_oauth_token() -> str | None:
     """Resolve a fresh token from the Omnigent host M2M profile."""
+    broker_url = os.environ.get("CODA_SP_TOKEN_BROKER_URL", "").strip()
+    if broker_url:
+        try:
+            with urlopen(broker_url, timeout=5) as response:
+                token = response.read().decode().strip()
+            if token:
+                return token
+        except Exception:
+            pass
     try:
         from databricks.sdk.core import Config
         headers = Config(profile=SP_PROFILE).authenticate()
@@ -64,6 +74,7 @@ import os
 import shutil
 import subprocess
 import sys
+from urllib.request import urlopen
 
 SP_PROFILE = "omnigents-host"
 # Set on the uv re-run so the child (which has the SDK) doesn't recurse.
@@ -71,6 +82,16 @@ _REEXEC_GUARD = "OMNIGENTS_APIKEY_HELPER_REEXEC"
 
 
 def _sp_oauth_token():
+    broker_url = os.environ.get("CODA_SP_TOKEN_BROKER_URL", "").strip()
+    if broker_url:
+        try:
+            with urlopen(broker_url, timeout=5) as response:
+                token = response.read().decode().strip()
+            if token:
+                return token
+        except Exception:
+            pass
+
     # Mint the SP token via the SDK. The M2M (client_id/secret) profile the
     # Omnigent host writes is NOT usable via `databricks auth token` (that CLI
     # verb is U2M-only and refuses M2M); Config.authenticate() does the

--- a/token_helper.py
+++ b/token_helper.py
@@ -24,8 +24,8 @@ from pathlib import Path
 SP_PROFILE = "omnigents-host"
 
 
-def resolve_databricks_token() -> str | None:
-    """Resolve a fresh SP OAuth token, falling back to the current PAT."""
+def resolve_sp_oauth_token() -> str | None:
+    """Resolve a fresh token from the Omnigent host M2M profile."""
     try:
         from databricks.sdk.core import Config
         headers = Config(profile=SP_PROFILE).authenticate()
@@ -35,6 +35,14 @@ def resolve_databricks_token() -> str | None:
             return token
     except Exception:
         pass
+    return None
+
+
+def resolve_databricks_token() -> str | None:
+    """Resolve a fresh SP OAuth token, falling back to the current PAT."""
+    token = resolve_sp_oauth_token()
+    if token:
+        return token
 
     token = os.environ.get("DATABRICKS_TOKEN", "").strip()
     if token:

--- a/token_helper.py
+++ b/token_helper.py
@@ -14,6 +14,7 @@ Both are resolved fresh on each invocation, so a long-running agent survives
 PAT rotation / SP-OAuth expiry without a restart.
 """
 
+import configparser
 import os
 import sys
 from pathlib import Path
@@ -21,6 +22,29 @@ from pathlib import Path
 # The SP OAuth profile the Omnigent host writes (auth_type=oauth-m2m). Kept in
 # sync with omnigents_host._HOST_PROFILE and setup_claude._SP_PROFILE.
 SP_PROFILE = "omnigents-host"
+
+
+def resolve_databricks_token() -> str | None:
+    """Resolve a fresh SP OAuth token, falling back to the current PAT."""
+    try:
+        from databricks.sdk.core import Config
+        headers = Config(profile=SP_PROFILE).authenticate()
+        auth = (headers or {}).get("Authorization", "")
+        token = auth[7:].strip() if auth.startswith("Bearer ") else auth.strip()
+        if token:
+            return token
+    except Exception:
+        pass
+
+    token = os.environ.get("DATABRICKS_TOKEN", "").strip()
+    if token:
+        return token
+    try:
+        config = configparser.ConfigParser()
+        config.read(os.path.expanduser("~/.databrickscfg"))
+        return config.get("DEFAULT", "token", fallback="").strip() or None
+    except Exception:
+        return None
 
 _HELPER_SRC = '''#!/usr/bin/env python3
 """Print a Databricks bearer token for Claude Code / Pi token resolution.


### PR DESCRIPTION
## What does this PR do?

- Preserves multibyte UTF-8 characters split across PTY reads.
- Decodes OpenCode SSE bytes explicitly as UTF-8.
- Enables app-SP OAuth for OpenCode and skips the PAT prompt in SP mode.
- Prefers rotated `[DEFAULT]` PATs over stale startup tokens.
- Prefers the loopback SP token broker when present, while retaining the existing fallback paths.
- Isolates MLflow autolog setup in unit tests.

## Test evidence

- [x] Combined stack `make test`: **459 passed, 1 skipped**.
- [x] Broker resolver regression coverage is included.
- [x] Deployed to `coding-agents-02` in the Lakemeter workspace as part of #100 verification.
- [x] Browser-driven PTY round-tripped `café Ελληνικά 日本語 😀` without replacement characters or Latin-1 mojibake.
- [x] Earlier Pi and OpenCode stress runs each produced 200 clean mixed-Unicode lines.

Pi conversation: `conv_b7e103fe3d1b4b71b471d7c8e68da331`

OpenCode conversation: `conv_0ea7d5c71538423f9df1214d7191a69e`
