### PR TITLE
fix(host): close Omnigent final-review gaps

### DIFF
--- a/HANDOFF-omnigents-host.md
+++ b/HANDOFF-omnigents-host.md
@@ -139,11 +139,8 @@ CoDA's container.
 ---
 
 ## Cleanup / hygiene owed
-- **Live PAT to revoke:** `bea9756ceb8e1656e8a00e454985784e6d239e7cdffc93cac85f22cf6ea9e9f4`
-  (comment `coda-auto-rotated`) — this is the CoDA-rotated token derived from the PAT pasted into
-  the terminal for log-debugging. It's CoDA's *active* terminal credential; revoke when done with
-  the terminal: `databricks tokens delete <id> --profile daveok`. (Earlier prior-session ~90-day
-  PAT was already revoked.)
+- **Exposed PAT:** the plaintext value has been removed from this public handoff. Treat every
+  token ever committed here as compromised and verify it is revoked before reusing the environment.
 - **`omnigents-daveok` app:** currently **RUNNING** (restarted this session for testing). To halt
   metering: `databricks apps stop omnigents-daveok --profile daveok`. App + its Lakebase branch
   (`projects/omnigents-daveok/branches/production` on the SHARED `ot-demo-lakebase` CU_1) stay
@@ -152,12 +149,12 @@ CoDA's container.
 ---
 
 ## Key environment facts (so you don't re-derive them)
-- coda app SP: `793257c7-63d3-464f-b6fb-3bc11880bf2d` (`app-2hnbfl coda`).
-- Stable host_id (deterministic): `host_30023c7760d5a8726abf9820d912b4e0`
+- coda app SP: `<coda-app-service-principal-client-id>`.
+- Stable host_id (deterministic): `host_<sha256-prefix>`
   = `_stable_host_identity()` = sha256(`coda-omnigents-host:<SP client_id>`).
 - Omnigent server runs **header auth mode** (default; accepts SP via proxy `X-Forwarded-Email`).
 - OSS source is the authoritative ref: `github.com/omnigent-ai/omnigent` (Databricks open-sourced
-  it 2026-06-13; same codebase as internal agent-framework). Use `gh api repos/omnigent-ai/omnigent/contents/<path> --jq .content | base64 -d` to read files (account: `david-okeeffe_data`).
+  it 2026-06-13; same codebase as internal agent-framework). Use `gh api repos/omnigent-ai/omnigent/contents/<path> --jq .content | base64 -d` to read files.
 - Host visibility = the identity on the tunnel at `omnigent host` launch; owner-scoped in
   `server/host_registry.py` + `auth.py`.
 - CoDA terminal driving (e2e): mint short-lived PAT → paste into terminal `Token:` gate (user

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ e2e-auth: ## Record SSO session for e2e tests (one-time per cookie expiry)
 	@url=$$(databricks apps get coding-agents --profile $(PROFILE) --output json 2>/dev/null \
 		| python3 -c "import sys,json; print(json.load(sys.stdin)['url'])") && \
 	echo "Recording SSO session against $$url ..." && \
-	uv run playwright codegen --save-storage tests/e2e/auth.json "$$url"
+	uv run python tests/e2e/record_auth.py "$$url" --output tests/e2e/auth.json
 	@echo ""
 	@echo "Auth state saved to tests/e2e/auth.json (gitignored)."
 	@echo "Run `make e2e-test PROFILE=$(PROFILE)` to execute the suite."
@@ -302,4 +302,3 @@ clean: ## Remove the app (destructive)
 	@databricks apps delete $(APP_NAME) --profile $(PROFILE) 2>/dev/null && \
 		echo "    App '$(APP_NAME)' deleted." || \
 		echo "    App '$(APP_NAME)' not found or already deleted."
-

--- a/app.py
+++ b/app.py
@@ -28,6 +28,7 @@ import enterprise_config
 from claude_otel import apply_claude_otel_env
 from utils import add_1m_context_suffix, ensure_https, get_gateway_host
 from pat_rotator import PATRotator
+from sp_token_broker import BROKER_URL_ENV, broker_url, mint_sp_token, start_sp_token_broker
 from telemetry import log_telemetry, set_product_info
 
 # Sanitize DATABRICKS_TOKEN early — the platform sometimes injects trailing
@@ -185,6 +186,7 @@ def _get_setup_state_snapshot():
 # Single-user security: only the token owner can access the terminal
 app_owner = None
 _omnigent_sp_creds = None
+_sp_token_broker_server = None
 
 
 def _owner_check_disabled() -> bool:
@@ -1879,7 +1881,7 @@ def close_session():
 
 def initialize_app(local_dev=False):
     """One-time init: detect owner, start cleanup thread."""
-    global app_owner, _omnigent_sp_creds
+    global app_owner, _omnigent_sp_creds, _sp_token_broker_server
 
     # Install SIGTERM handler only for gunicorn (production).
     # For local dev, SIG_DFL is fine — the process just exits cleanly.
@@ -1903,16 +1905,23 @@ def initialize_app(local_dev=False):
     else:
         logger.warning("Could not determine app owner - authorization disabled")
 
-    # SP-auth workshop path: write the omnigents-host OAuth (M2M) profile at
-    # boot from the app's OWN SP creds, so token_helper._sp_oauth_token()
-    # resolves without a pasted PAT. Normally _write_oauth_profile runs only
-    # when OMNIGENTS_SERVER_URL is set (host path); the workshop app omits that
-    # var, so arm it here when ENABLE_SP_APIKEYHELPER=true. Idempotent; no-op
-    # without SP creds (local dev / per-user deploy keeps the PAT path).
-    if _omnigent_sp_creds and os.environ.get("ENABLE_SP_APIKEYHELPER", "").strip().lower() in ("true", "1", "yes"):
+    sp_helper_enabled = os.environ.get("ENABLE_SP_APIKEYHELPER", "").strip().lower() in (
+        "true", "1", "yes",
+    )
+    host_enabled = bool(os.environ.get("OMNIGENTS_SERVER_URL", "").strip())
+    if _omnigent_sp_creds and (sp_helper_enabled or host_enabled):
+        _sp_token_broker_server = start_sp_token_broker(
+            lambda: mint_sp_token(_omnigent_sp_creds)
+        )
+        os.environ[BROKER_URL_ENV] = broker_url(_sp_token_broker_server)
+        logger.info("SP token broker listening on loopback")
+
+    # The profile retains only the workspace host for Omnigent routing. The
+    # long-lived client secret stays in this process; helpers mint via broker.
+    if _omnigent_sp_creds and sp_helper_enabled:
         from omnigents_host import _write_oauth_profile
         _write_oauth_profile(_omnigent_sp_creds)
-        logger.info("SP apikeyhelper: wrote omnigents-host OAuth profile at boot (no PAT paste needed)")
+        logger.info("SP apikeyhelper: wrote secret-free host profile at boot")
 
     # Strip SP credentials — only needed for owner resolution above.
     # Keeping them causes SDK to silently fall back to SP auth when PAT is dead.

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -77,12 +77,14 @@ Key runtime facts an agent should know:
   `setup_*.py`); agent CLIs install in parallel. `RUNNING` app status only
   means gunicorn bound the port — check `/api/setup-status` or boot logs before
   claiming setup-dependent features work.
-- **Auth (layered):** with `ENABLE_SP_APIKEYHELPER=true`, the app writes its own
-  SP OAuth profile at boot and all agents install without a paste. A short-lived
+- **Auth (layered):** with `ENABLE_SP_APIKEYHELPER=true`, the app keeps its SP
+  client secret in-process and brokers short-lived OAuth tokens over loopback;
+  the on-disk `omnigents-host` profile contains only the workspace host. Agents
+  install without a paste. A short-lived
   PAT pasted on first terminal session is the **fallback** and **auto-rotates
   every 10 min** (`pat_rotator.py`). The rotator rewrites `~/.databrickscfg` on
   every rotation — a known failure mode was clobbering co-owned profiles (e.g.
-  `omnigents-host` OAuth); fixed in `b5b11a6`, but any CLI call that must use
+  `omnigents-host`); fixed in `b5b11a6`, but any CLI call that must use
   the file profile should go through `databrickscfg_only_env()` (see `utils.py`).
 - Databricks CLI: in the **container**, test with `databricks current-user me`.
   On a **local Mac**, use `databricks auth describe --profile <profile>`.
@@ -153,7 +155,7 @@ of the live `coda` app can wedge platform boot.
 
 ## 3. Databricks auth notes (gotchas)
 
-- **Layered auth in-container:** SP OAuth at boot (`ENABLE_SP_APIKEYHELPER`) is
+- **Layered auth in-container:** brokered SP OAuth at boot (`ENABLE_SP_APIKEYHELPER`) is
   tried first; pasted PAT is the fallback. These coexist by design — not
   "PAT or CLIENT_ID/SECRET, pick one."
 - Ambient app-SP env vars can shadow a `~/.databrickscfg` profile. The sync uses

--- a/docs/auth-and-identity.md
+++ b/docs/auth-and-identity.md
@@ -4,19 +4,19 @@ Reference for who does what on a running CoDA host (e.g. `coda-01`..`coda-08`),
 how each agent authenticates its model calls, and the known zero-PAT gap for
 OpenCode / Hermes. Written 2026-07-11.
 
-## TL;DR â two identities, don't confuse them
+## TL;DR — two identities, don't confuse them
 
 A CoDA container carries **two separate Databricks identities**:
 
 | Identity | What it is | What it's used for |
 |---|---|---|
-| **The user** (e.g. `david.okeeffe1@coles.com.au`) via the PAT in `~/.databrickscfg [DEFAULT]` | A **user** personal access token (`dapiâ¦`), kept fresh by the PAT rotator | **Everything the terminal / CLI does**: `databricks` commands, `git`, `gh`, workspace/UC ops, file writes. Also the token the content-filter proxy injects for OpenCode / Hermes / Codex model calls. |
+| **The user** (e.g. `user@example.com`) via the PAT in `~/.databrickscfg [DEFAULT]` | A **user** personal access token (`dapi…`), kept fresh by the PAT rotator | **Everything the terminal / CLI does**: `databricks` commands, `git`, `gh`, workspace/UC ops, file writes. Also the token the content-filter proxy injects for OpenCode / Hermes / Codex model calls. |
 | **The app service principal** (e.g. `app-4n8qml coda-02`, an OAuth client_id) | The Databricks App's own SP, no PAT | **Claude & Pi model inference** (via the `apiKeyHelper` / `!command` that mints an **SP-OAuth** token from the `omnigents-host` profile), plus the Omnigent host registration / tunnel. |
 
 ### So: when Claude runs a command on this box, who is it?
 
-**You.** Any shell command Claude Code runs â `git commit`, `databricks â¦`, file
-edits â authenticates with the **injected user PAT** in `~/.databrickscfg`, so it
+**You.** Any shell command Claude Code runs — `git commit`, `databricks …`, file
+edits — authenticates with the **injected user PAT** in `~/.databrickscfg`, so it
 acts as **your user identity**, not the app SP. That's why commits/pushes show as
 you and CLI calls have your grants.
 
@@ -24,7 +24,7 @@ Only the **model inference** for Claude/Pi uses the app SP (zero-PAT, via the
 token helper). The shell/tools do not.
 
 > Consequence: on a **shared team CoDA**, everyone on that host shares the one
-> injected PAT â so terminal actions all run as whoever injected it (the host
+> injected PAT — so terminal actions all run as whoever injected it (the host
 > owner), regardless of which teammate is driving. Segregation is at the Omnigent
 > host-share layer, not per-user identity inside the box.
 
@@ -34,9 +34,9 @@ token helper). The shell/tools do not.
 |---|---|---|
 | **Claude** | `apiKeyHelper` in `~/.claude/settings.json` (shared `token_helper.py`) | yes |
 | **Pi** | `!command` apiKey in `~/.pi/agent/models.json` (same `token_helper.py`) | yes |
-| **OpenCode** | `baseURL` â local **content-filter proxy** (`127.0.0.1:4000`), which injects a fresh token per request | â ï¸ only after a PAT is injected once |
-| **Hermes** | routes via the **content-filter proxy** too (same fresh-token injection) | â ï¸ only after a PAT is injected once |
-| **Codex** | content-filter proxy | â ï¸ same as above |
+| **OpenCode** | `baseURL` → local **content-filter proxy** (`127.0.0.1:4000`), which injects a fresh token per request | ⚠️ only after a PAT is injected once |
+| **Hermes** | routes via the **content-filter proxy** too (same fresh-token injection) | ⚠️ only after a PAT is injected once |
+| **Codex** | content-filter proxy | ⚠️ same as above |
 
 ### Why Claude/Pi are zero-PAT but OpenCode/Hermes aren't
 
@@ -46,21 +46,21 @@ token helper). The shell/tools do not.
 - **OpenCode / Hermes / Codex** route through `content_filter_proxy.py`, whose
   `_get_fresh_token()` reads the current token from **`~/.databrickscfg`**
   (`content_filter_proxy.py:54`, injected at `:569-573`). The PAT rotator keeps
-  that file fresh â **but only after a PAT has been bootstrapped**. On the pure
+  that file fresh — **but only after a PAT has been bootstrapped**. On the pure
   SP-OAuth host path there is no PAT, so `~/.databrickscfg` has no token to read
   until you inject one in the UI. That's the one-time PAT injection.
 - Once injected, the proxy keeps OpenCode/Hermes fresh across PAT rotation with
-  no further injection (that's the dynamic-refresh mechanism â it's not static).
+  no further injection (that's the dynamic-refresh mechanism — it's not static).
 
-## Known gap / future fix (not done â intentional)
+## Known gap / future fix (not done — intentional)
 
 To make **OpenCode / Hermes** zero-PAT like Claude/Pi, teach
 `content_filter_proxy._get_fresh_token()` to **fall back to minting an SP-OAuth
 token** from the `omnigents-host` profile (the same source `token_helper.py`
 uses) when no PAT is present in `~/.databrickscfg`. Small, well-scoped change:
 
-- `content_filter_proxy.py` â add an SP-OAuth mint (via `databricks.sdk` `Config(profile="omnigents-host").authenticate()`) as the fallback in `_get_fresh_token()`, cached with a short TTL like the current path.
-- No change needed to `setup_opencode.py` / `setup_hermes.py` â they already
+- `content_filter_proxy.py` — add an SP-OAuth mint (via `databricks.sdk` `Config(profile="omnigents-host").authenticate()`) as the fallback in `_get_fresh_token()`, cached with a short TTL like the current path.
+- No change needed to `setup_opencode.py` / `setup_hermes.py` — they already
   route through the proxy; only the proxy's token source needs the fallback.
 
 Decision (2026-07-11): **left as-is.** "Claude/Pi work with no PAT; Hermes/OpenCode
@@ -68,10 +68,10 @@ work after a one-time PAT injection" is acceptable for the workshop.
 
 ## Key files
 
-- `token_helper.py` â shared SP-OAuth/PAT resolver for Claude (`apiKeyHelper`) and Pi (`!command`).
-- `setup_claude.py` / `setup_pi.py` â wire the helper (default-on; opt out via `DISABLE_SP_APIKEYHELPER`).
-- `content_filter_proxy.py` â local proxy for OpenCode/Hermes/Codex; `_get_fresh_token()` (`:54`) + header injection (`:569-573`).
-- `setup_opencode.py` / `setup_hermes.py` â point the agent at the proxy (`127.0.0.1:4000`).
-- `pat_rotator.py` â mints/rotates the user PAT, writes `~/.databrickscfg`, fans out via `cli_auth.py`.
-- `cli_auth.py` â on rotation, refreshes static tokens in each agent's config (skips the `!command` / helper-owned ones).
-- `omnigents_host.py` â host path: `_ensure_{claude,pi,opencode}_settings()` re-run setup with a minted SP bearer on host-connect.
+- `token_helper.py` — shared SP-OAuth/PAT resolver for Claude (`apiKeyHelper`) and Pi (`!command`).
+- `setup_claude.py` / `setup_pi.py` — wire the helper (default-on; opt out via `DISABLE_SP_APIKEYHELPER`).
+- `content_filter_proxy.py` — local proxy for OpenCode/Hermes/Codex; `_get_fresh_token()` (`:54`) + header injection (`:569-573`).
+- `setup_opencode.py` / `setup_hermes.py` — point the agent at the proxy (`127.0.0.1:4000`).
+- `pat_rotator.py` — mints/rotates the user PAT, writes `~/.databrickscfg`, fans out via `cli_auth.py`.
+- `cli_auth.py` — on rotation, refreshes static tokens in each agent's config (skips the `!command` / helper-owned ones).
+- `omnigents_host.py` — host path: `_ensure_{claude,pi,opencode}_settings()` re-run setup with a minted SP bearer on host-connect.

--- a/grant_omnigent_host.sh
+++ b/grant_omnigent_host.sh
@@ -5,7 +5,7 @@
 # For a deployed CoDA app to appear as a selectable host in the Omnigent picker,
 # its container must successfully run `omnigent host <server>`. That requires the
 # app's service principal to have BOTH:
-#   1. CAN_USE on the Omnigent server app  â or the host tunnel (WebSocket
+#   1. CAN_USE on the Omnigent server app — or the host tunnel (WebSocket
 #      upgrade) is rejected and the host never registers.
 #   2. UC access to the wheel volume = the FULL traversal chain:
 #        a. USE_CATALOG on the catalog
@@ -136,7 +136,7 @@ for a in d.get('privilege_assignments',[]):
 missing=[p for p in ('READ_VOLUME','WRITE_VOLUME') if p not in have]
 print(','.join(missing))")
 if [[ -z "$MISSING" ]]; then
-  echo "    already granted Ã¢ skipping"
+  echo "    already granted — skipping"
 else
   ADD_JSON=$(CODA_SP="$CODA_SP" MISSING="$MISSING" python3 -c "
 import os,json

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -825,7 +825,7 @@ def _run_host_once(server_url: str, stop_event: threading.Event | None = None) -
     # would otherwise shadow the profile in the SDK's unified-auth resolution.
     # In particular DATABRICKS_WORKSPACE_ID + the DATABRICKS_APP_* vars (which
     # Apps injects) steer auth to the app's ambient identity and cause the
-    # tunnel to 302 â OIDC even with the M2M profile present. Verified: a clean
+    # tunnel to 302 → OIDC even with the M2M profile present. Verified: a clean
     # env with only the profile vars connects; leaving these in does not.
     env = config_profile_env(_HOST_PROFILE)
     local_bin = os.path.join(home, ".local", "bin")

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -24,6 +24,7 @@ CoDA behaves exactly as before.
 
 from __future__ import annotations
 
+import configparser
 import hashlib
 import json
 import logging
@@ -314,27 +315,25 @@ def _write_oauth_profile(creds: dict[str, str]) -> None:
     home = os.environ.get("HOME", "/app/python/source_code")
     cfg_path = os.path.join(home, ".databrickscfg")
 
-    # auth_type = oauth-m2m is REQUIRED: without it the CLI/SDK doesn't infer
-    # client-credentials from client_id/secret and fails with "OAuth is not
-    # configured for this host" — so the host tunnel never gets an M2M token.
-    profile_block = (
-        f"\n[{_HOST_PROFILE}]\n"
-        f"host = {creds['host']}\n"
-        f"client_id = {creds['client_id']}\n"
-        f"client_secret = {creds['client_secret']}\n"
-        f"auth_type = oauth-m2m\n"
-    )
-
-    # Append only if the profile isn't already present (idempotent across
-    # restarts). The PAT rotator owns [DEFAULT]; we only ever touch our block.
-    existing = ""
+    config = configparser.ConfigParser(interpolation=None)
     if os.path.exists(cfg_path):
-        with open(cfg_path) as f:
-            existing = f.read()
-    if f"[{_HOST_PROFILE}]" in existing:
-        return
-    with open(cfg_path, "a") as f:
-        f.write(profile_block)
+        config.read(cfg_path)
+    config[_HOST_PROFILE] = {
+        "host": creds["host"],
+        "client_id": creds["client_id"],
+        "client_secret": creds["client_secret"],
+        "auth_type": "oauth-m2m",
+    }
+
+    fd, tmp_path = tempfile.mkstemp(dir=home, prefix=".databrickscfg.")
+    try:
+        with os.fdopen(fd, "w") as f:
+            config.write(f)
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, cfg_path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
     logger.info("Wrote OAuth profile '%s' for Omnigents host tunnel", _HOST_PROFILE)
 
 

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -29,6 +29,7 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import select
 import subprocess
 import sys
@@ -38,6 +39,8 @@ import time
 
 import yaml
 
+from sp_token_broker import fetch_sp_token
+from token_helper import write_databricks_token_wrapper
 from utils import config_profile_env, ensure_https
 
 logger = logging.getLogger(__name__)
@@ -306,12 +309,7 @@ def capture_sp_credentials() -> dict[str, str] | None:
 
 
 def _write_oauth_profile(creds: dict[str, str]) -> None:
-    """Write an OAuth (M2M) profile to ~/.databrickscfg for the host.
-
-    Uses the Databricks SDK config-file format so ``omnigents host
-    --profile omnigents-host`` resolves an OAuth token (client-credentials
-    flow) rather than a PAT — the token type the Apps proxy accepts.
-    """
+    """Write the broker-owned workspace pointer without persisting SP creds."""
     home = os.environ.get("HOME", "/app/python/source_code")
     cfg_path = os.path.join(home, ".databrickscfg")
 
@@ -320,9 +318,6 @@ def _write_oauth_profile(creds: dict[str, str]) -> None:
         config.read(cfg_path)
     config[_HOST_PROFILE] = {
         "host": creds["host"],
-        "client_id": creds["client_id"],
-        "client_secret": creds["client_secret"],
-        "auth_type": "oauth-m2m",
     }
 
     fd, tmp_path = tempfile.mkstemp(dir=home, prefix=".databrickscfg.")
@@ -334,7 +329,7 @@ def _write_oauth_profile(creds: dict[str, str]) -> None:
     finally:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
-    logger.info("Wrote OAuth profile '%s' for Omnigents host tunnel", _HOST_PROFILE)
+    logger.info("Wrote secret-free profile '%s' for Omnigent runner routing", _HOST_PROFILE)
 
 
 def _ensure_claude() -> None:
@@ -805,32 +800,42 @@ def _configure_omnigent_databricks_auth() -> None:
         logger.warning("could not pin omnigent databricks auth (non-fatal): %s", e)
 
 
+def _install_broker_cli_wrapper() -> None:
+    """Intercept only Omnigent's profile token command; delegate all other CLI use."""
+    real_cli = shutil.which("databricks")
+    if not real_cli:
+        raise RuntimeError("Databricks CLI is required for Omnigent native harness auth")
+    home = os.environ.get("HOME", "/app/python/source_code")
+    wrapper_dir = os.path.join(home, ".coda-broker-bin")
+    wrapper = write_databricks_token_wrapper(wrapper_dir, real_cli)
+    logger.info("Installed Omnigent token-broker CLI wrapper at %s", wrapper)
+
+
 def _run_host_once(server_url: str, stop_event: threading.Event | None = None) -> int:
     """Run ``omnigents host`` in the foreground until it exits. Returns rc."""
     global _proc
 
     home = os.environ.get("HOME", "/app/python/source_code")
     # `omnigent host` takes only the server URL (no --profile on current main).
-    # Auth is driven by DATABRICKS_CONFIG_PROFILE in the env below.
     cmd = [_omnigents_bin(), "host", server_url]
 
     # The runner inherits this env; CoDA's ANTHROPIC_* AI-Gateway creds are
     # already present and get forwarded host→runner via Omnigents'
-    # HARNESS_CREDENTIAL_ENV_VARS. We do NOT inject the SP secret here — the
-    # host resolves it from the OAuth profile we wrote.
-    # Omnigents' token factory calls _resolve_databricks_auth() WITHOUT a
-    # profile, so `--profile` is ignored for the tunnel token; it uses the
-    # SDK's default resolution. Point that resolution at our M2M profile via
-    # DATABRICKS_CONFIG_PROFILE, and clear every ambient Databricks env var that
-    # would otherwise shadow the profile in the SDK's unified-auth resolution.
-    # In particular DATABRICKS_WORKSPACE_ID + the DATABRICKS_APP_* vars (which
-    # Apps injects) steer auth to the app's ambient identity and cause the
-    # tunnel to 302 → OIDC even with the M2M profile present. Verified: a clean
-    # env with only the profile vars connects; leaving these in does not.
+    # HARNESS_CREDENTIAL_ENV_VARS. We never inject the SP secret here. Fetch a
+    # short-lived bearer from the loopback broker for this tunnel launch and
+    # clear ambient Databricks vars that could shadow it in unified auth.
     env = config_profile_env(_HOST_PROFILE)
+    env.pop("DATABRICKS_CONFIG_PROFILE", None)
+    token = fetch_sp_token()
+    if not token:
+        raise RuntimeError("SP token broker returned no token for host launch")
+    env["DATABRICKS_HOST"] = (_sp_creds or {}).get("host", "")
+    env["DATABRICKS_TOKEN"] = token
+    env["DATABRICKS_AUTH_TYPE"] = "pat"
     local_bin = os.path.join(home, ".local", "bin")
-    if local_bin not in env.get("PATH", ""):
-        env["PATH"] = f"{local_bin}:{env.get('PATH', '')}"
+    broker_bin = os.path.join(home, ".coda-broker-bin")
+    path_parts = [broker_bin, local_bin, env.get("PATH", "")]
+    env["PATH"] = ":".join(part for part in path_parts if part)
     stable_identity = _stable_host_identity()
     if stable_identity is not None:
         env.setdefault("OMNIGENT_HOST_ID", stable_identity[0])
@@ -904,8 +909,9 @@ def _supervise(
     _set(installed=True, stage="writing_profile")
     try:
         _write_oauth_profile(sp_creds)
+        _install_broker_cli_wrapper()
     except Exception as e:
-        logger.warning("Could not write OAuth host profile: %s; host NOT started", e)
+        logger.warning("Could not configure broker-backed host auth: %s; host NOT started", e)
         _set(stage="profile_failed", last_error=str(e))
         return
     # Configure harnesses from CoDA's ambient LLM creds so runners can auth

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -12,8 +12,8 @@ Two credentials, two jobs (see GOAL.md §3):
   the server **rejects PATs (302 → OIDC login) and accepts OAuth / service-
   principal tokens**, so the host MUST present an OAuth token minted from the
   app SP's ``DATABRICKS_CLIENT_ID`` / ``DATABRICKS_CLIENT_SECRET``. CoDA strips
-  those creds from the environment early in startup, so we capture them
-  *before* that strip and write a short-lived OAuth profile for the host.
+  those creds from the environment early in startup, so we capture them in the
+  app process and expose only short-lived tokens through a loopback broker.
 * **Harness LLM** — the runner the host spawns authenticates to AI Gateway via
   CoDA's already-injected ``ANTHROPIC_*`` env, forwarded host→runner by
   Omnigents' ``HARNESS_CREDENTIAL_ENV_VARS``. No new LLM credential is minted.
@@ -769,8 +769,9 @@ def _configure_omnigent_databricks_auth() -> None:
     this fixes all three harnesses on the runner, not just Pi.
 
     So overwrite the ``auth`` block with ``{type: databricks, profile:
-    omnigents-host}`` — the profile ``_write_oauth_profile`` already wrote. Read-
-    merge-write to preserve setup's other keys; idempotent; best-effort.
+    omnigents-host}``. That profile contains only the workspace host; its token
+    command is intercepted by the loopback-broker CLI shim. Read-merge-write to
+    preserve setup's other keys; idempotent; best-effort.
     """
     home = os.environ.get("HOME", "/app/python/source_code")
     config_path = os.path.join(home, ".omnigent", "config.yaml")

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -31,6 +31,7 @@ import logging
 import os
 import shutil
 import select
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -833,6 +834,9 @@ def _run_host_once(server_url: str, stop_event: threading.Event | None = None) -
     env["DATABRICKS_HOST"] = (_sp_creds or {}).get("host", "")
     env["DATABRICKS_TOKEN"] = token
     env["DATABRICKS_AUTH_TYPE"] = "pat"
+    env["OMNIGENT_DATABRICKS_TOKEN_COMMAND"] = shlex.join(
+        [sys.executable, os.path.join(home, ".claude", "anthropic-token-helper.py")]
+    )
     local_bin = os.path.join(home, ".local", "bin")
     broker_bin = os.path.join(home, ".coda-broker-bin")
     path_parts = [broker_bin, local_bin, env.get("PATH", "")]

--- a/sp_token_broker.py
+++ b/sp_token_broker.py
@@ -1,0 +1,80 @@
+"""Loopback-only broker for short-lived CoDA app service-principal tokens."""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.request import urlopen
+
+BROKER_URL_ENV = "CODA_SP_TOKEN_BROKER_URL"
+
+
+def mint_sp_token(creds: dict[str, str]) -> str:
+    """Mint a fresh M2M bearer without persisting the client secret."""
+    from databricks.sdk.core import Config
+
+    headers = Config(
+        host=creds["host"],
+        client_id=creds["client_id"],
+        client_secret=creds["client_secret"],
+        auth_type="oauth-m2m",
+    ).authenticate()
+    auth = (headers or {}).get("Authorization", "")
+    token = auth[7:].strip() if auth.startswith("Bearer ") else auth.strip()
+    if not token:
+        raise RuntimeError("app service principal returned no bearer token")
+    return token
+
+
+def start_sp_token_broker(
+    mint_token: Callable[[], str], *, port: int = 0
+) -> ThreadingHTTPServer:
+    """Start a daemon HTTP server bound only to IPv4 loopback."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+            if self.path != "/token":
+                self.send_error(404)
+                return
+            try:
+                body = mint_token().encode()
+            except Exception:
+                self.send_error(503)
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    server.daemon_threads = True
+    threading.Thread(
+        target=server.serve_forever,
+        daemon=True,
+        name="sp-token-broker",
+    ).start()
+    return server
+
+
+def broker_url(server: ThreadingHTTPServer) -> str:
+    """Return the token URL for a running broker."""
+    host, port = server.server_address[:2]
+    return f"http://{host}:{port}/token"
+
+
+def fetch_sp_token(url: str | None = None) -> str | None:
+    """Fetch a fresh bearer from the configured loopback broker."""
+    target = (url or os.environ.get(BROKER_URL_ENV, "")).strip()
+    if not target:
+        return None
+    try:
+        with urlopen(target, timeout=5) as response:
+            return response.read().decode().strip() or None
+    except Exception:
+        return None

--- a/tests/e2e/record_auth.py
+++ b/tests/e2e/record_auth.py
@@ -1,0 +1,35 @@
+"""Record Databricks Apps SSO state and exit once redirected to CoDA."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from urllib.parse import urlparse
+
+from playwright.sync_api import sync_playwright
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("url")
+    parser.add_argument("--output", default=str(Path(__file__).with_name("auth.json")))
+    args = parser.parse_args()
+    target_host = urlparse(args.url).netloc
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=False)
+        context = browser.new_context()
+        page = context.new_page()
+        page.goto(args.url)
+        page.wait_for_function(
+            "host => location.host === host && !location.pathname.startsWith('/login')",
+            arg=target_host,
+            timeout=300_000,
+        )
+        context.storage_state(path=args.output)
+        browser.close()
+    print(f"Auth state saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/test_live_sp_token_broker.py
+++ b/tests/e2e/test_live_sp_token_broker.py
@@ -1,0 +1,103 @@
+"""Drive a deployed CoDA PTY and verify the brokered SP credential boundary."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import time
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+
+from tests.e2e.test_live_security import _read_output, _send_input
+
+
+def _probe_command() -> str:
+    script = r'''
+import configparser
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+cfg = configparser.ConfigParser()
+cfg.read(pathlib.Path.home() / ".databrickscfg")
+profile = dict(cfg["omnigents-host"])
+helper = pathlib.Path.home() / ".claude" / "anthropic-token-helper.py"
+helper_run = subprocess.run([sys.executable, str(helper)], capture_output=True, text=True)
+wrapper_run = subprocess.run(
+    [str(pathlib.Path.home() / ".coda-broker-bin" / "databricks"),
+     "auth", "token", "--profile", "omnigents-host", "--output", "json"],
+    capture_output=True,
+    text=True,
+)
+try:
+    wrapper_token = json.loads(wrapper_run.stdout).get("access_token", "")
+except Exception:
+    wrapper_token = ""
+
+result = {
+    "profile_keys": sorted(profile),
+    "secret_free_profile": not ({"client_id", "client_secret", "token"} & set(profile)),
+    "secret_free_env": "DATABRICKS_CLIENT_SECRET" not in os.environ,
+    "helper_ok": helper_run.returncode == 0 and len(helper_run.stdout.strip()) > 20,
+    "wrapper_ok": wrapper_run.returncode == 0 and len(wrapper_token) > 20,
+    "unicode": "café Ελληνικά 日本語 😀",
+}
+print("BROKER-E2E=" + json.dumps(result, ensure_ascii=False))
+'''
+    encoded = base64.b64encode(script.encode()).decode()
+    return f"echo {encoded} | base64 -d | python3; echo BROKER-E2E-EXIT=$?"
+
+
+def test_live_sp_token_broker_and_unicode(page, app_url):
+    page.goto(app_url, timeout=30_000)
+    page.wait_for_function(
+        """async () => {
+            try {
+                const r = await fetch('/api/sessions', {credentials: 'include'});
+                return r.ok;
+            } catch (_) {
+                return false;
+            }
+        }""",
+        timeout=180_000,
+    )
+
+    new_session = page.evaluate(
+        """async () => {
+            const r = await fetch('/api/session', {
+                method: 'POST',
+                credentials: 'include',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({label: 'broker-e2e'}),
+            });
+            return r.json();
+        }"""
+    )
+    sid = new_session["session_id"]
+    time.sleep(2)
+    _read_output(page, sid)
+    _send_input(page, sid, _probe_command())
+
+    deadline = time.time() + 60
+    output = ""
+    exit_re = re.compile(r"BROKER-E2E-EXIT=(\d+)")
+    while time.time() < deadline and not exit_re.search(output):
+        output += _read_output(page, sid)
+        time.sleep(0.5)
+
+    match = re.search(r"BROKER-E2E=(\{.*\})", output)
+    assert match, output[-3000:]
+    result = json.loads(match.group(1))
+    assert result["profile_keys"] == ["host"]
+    assert result["secret_free_profile"] is True
+    assert result["secret_free_env"] is True
+    assert result["helper_ok"] is True
+    assert result["wrapper_ok"] is True
+    assert result["unicode"] == "café Ελληνικά 日本語 😀"
+    assert not re.search(r"Ã|Â|â|ðŸ|�", output)
+    assert exit_re.search(output).group(1) == "0"

--- a/tests/test_apikey_helper.py
+++ b/tests/test_apikey_helper.py
@@ -44,6 +44,13 @@ class TestSpBranch:
 
         assert token_helper.resolve_sp_oauth_token() == "broker-token"
 
+    def test_broker_token_wins_without_persisted_profile(self, monkeypatch):
+        mod = _load_helper_module()
+        monkeypatch.setenv("CODA_SP_TOKEN_BROKER_URL", "http://127.0.0.1:4010/token")
+        monkeypatch.setattr(mod, "urlopen", lambda *_a, **_k: _BrokerResponse(b"broker-tok"))
+
+        assert mod._sp_oauth_token() == "broker-tok"
+
     def test_sdk_mint_strips_bearer_prefix(self, monkeypatch):
         """SP path returns the raw token with 'Bearer ' stripped."""
         mod = _load_helper_module()

--- a/tests/test_omnigents_host.py
+++ b/tests/test_omnigents_host.py
@@ -8,6 +8,8 @@ without the OAuth-capable SP creds (a PAT alone is rejected by the Apps proxy).
 from __future__ import annotations
 
 import hashlib
+import shlex
+import sys
 
 import yaml
 
@@ -276,6 +278,9 @@ def test_run_host_once_prepends_local_bin_to_path(monkeypatch, tmp_path):
     assert env["OMNIGENT_HOST_NAME"] == "coda"
     assert env["DATABRICKS_TOKEN"] == "short-lived-token"
     assert env["DATABRICKS_HOST"] == "https://ambient.example.com"
+    assert env["OMNIGENT_DATABRICKS_TOKEN_COMMAND"] == (
+        shlex.join([sys.executable, str(tmp_path / ".claude" / "anthropic-token-helper.py")])
+    )
     assert "DATABRICKS_CONFIG_PROFILE" not in env
     assert "DATABRICKS_CLIENT_SECRET" not in env
 

--- a/tests/test_omnigents_host.py
+++ b/tests/test_omnigents_host.py
@@ -201,6 +201,27 @@ def test_write_oauth_profile_is_idempotent(monkeypatch, tmp_path):
     assert "client_id = cid" in cfg
 
 
+def test_write_oauth_profile_refreshes_rotated_credentials(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_path = tmp_path / ".databrickscfg"
+    cfg_path.write_text("[DEFAULT]\ntoken = dapi-user\n")
+
+    oh._write_oauth_profile(
+        {"client_id": "old-id", "client_secret": "old-secret", "host": "https://old"}
+    )
+    oh._write_oauth_profile(
+        {"client_id": "new-id", "client_secret": "new-secret", "host": "https://new"}
+    )
+
+    cfg = cfg_path.read_text()
+    assert "token = dapi-user" in cfg
+    assert "client_id = new-id" in cfg
+    assert "client_secret = new-secret" in cfg
+    assert "host = https://new" in cfg
+    assert "old-secret" not in cfg
+    assert cfg.count(f"[{oh._HOST_PROFILE}]") == 1
+
+
 def test_run_host_once_prepends_local_bin_to_path(monkeypatch, tmp_path):
     oh.reset_for_tests()
     monkeypatch.setenv("HOME", str(tmp_path))

--- a/tests/test_omnigents_host.py
+++ b/tests/test_omnigents_host.py
@@ -191,14 +191,17 @@ def test_capture_sp_credentials_adds_https_scheme(monkeypatch):
     assert creds["host"] == "https://adb-123.azuredatabricks.net"
 
 
-def test_write_oauth_profile_is_idempotent(monkeypatch, tmp_path):
+def test_write_oauth_profile_contains_host_but_no_long_lived_secret(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     creds = {"client_id": "cid", "client_secret": "sec", "host": "https://h"}
     oh._write_oauth_profile(creds)
     oh._write_oauth_profile(creds)  # second call must not duplicate the block
     cfg = (tmp_path / ".databrickscfg").read_text()
     assert cfg.count(f"[{oh._HOST_PROFILE}]") == 1
-    assert "client_id = cid" in cfg
+    assert "host = https://h" in cfg
+    assert "client_id" not in cfg
+    assert "client_secret" not in cfg
+    assert "token" not in cfg
 
 
 def test_write_oauth_profile_refreshes_rotated_credentials(monkeypatch, tmp_path):
@@ -215,10 +218,9 @@ def test_write_oauth_profile_refreshes_rotated_credentials(monkeypatch, tmp_path
 
     cfg = cfg_path.read_text()
     assert "token = dapi-user" in cfg
-    assert "client_id = new-id" in cfg
-    assert "client_secret = new-secret" in cfg
     assert "host = https://new" in cfg
     assert "old-secret" not in cfg
+    assert "new-secret" not in cfg
     assert cfg.count(f"[{oh._HOST_PROFILE}]") == 1
 
 
@@ -229,10 +231,14 @@ def test_run_host_once_prepends_local_bin_to_path(monkeypatch, tmp_path):
     monkeypatch.setenv("DATABRICKS_APP_NAME", "coda")
     monkeypatch.setenv("DATABRICKS_HOST", "https://ambient.example.com")
     monkeypatch.setattr(oh, "_omnigents_bin", lambda: "/bin/omnigent")
+    monkeypatch.setattr(oh, "fetch_sp_token", lambda: "short-lived-token")
     monkeypatch.setattr(
         oh,
         "_sp_creds",
-        {"client_id": "793257c7-63d3-464f-b6fb-3bc11880bf2d"},
+        {
+            "client_id": "793257c7-63d3-464f-b6fb-3bc11880bf2d",
+            "host": "https://ambient.example.com",
+        },
     )
 
     captured = {}
@@ -262,11 +268,16 @@ def test_run_host_once_prepends_local_bin_to_path(monkeypatch, tmp_path):
         b"coda-omnigents-host:793257c7-63d3-464f-b6fb-3bc11880bf2d"
     ).hexdigest()[:32]
     assert captured["cwd"] == str(tmp_path)
-    assert env["PATH"].split(":")[0] == str(tmp_path / ".local" / "bin")
+    assert env["PATH"].split(":")[:2] == [
+        str(tmp_path / ".coda-broker-bin"),
+        str(tmp_path / ".local" / "bin"),
+    ]
     assert env["OMNIGENT_HOST_ID"] == expected_host_id
     assert env["OMNIGENT_HOST_NAME"] == "coda"
-    assert env["DATABRICKS_CONFIG_PROFILE"] == oh._HOST_PROFILE
-    assert "DATABRICKS_HOST" not in env
+    assert env["DATABRICKS_TOKEN"] == "short-lived-token"
+    assert env["DATABRICKS_HOST"] == "https://ambient.example.com"
+    assert "DATABRICKS_CONFIG_PROFILE" not in env
+    assert "DATABRICKS_CLIENT_SECRET" not in env
 
 
 def _fail(name):

--- a/tests/test_sp_token_broker.py
+++ b/tests/test_sp_token_broker.py
@@ -1,0 +1,74 @@
+import json
+import os
+import subprocess
+from urllib.request import urlopen
+
+import sp_token_broker as broker
+from token_helper import write_databricks_token_wrapper
+
+
+def test_broker_binds_loopback_and_mints_per_request():
+    tokens = iter(("first-token", "second-token"))
+    server = broker.start_sp_token_broker(lambda: next(tokens), port=0)
+    try:
+        assert server.server_address[0] == "127.0.0.1"
+        url = broker.broker_url(server)
+        assert urlopen(url, timeout=2).read().decode() == "first-token"
+        assert urlopen(url, timeout=2).read().decode() == "second-token"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_fetch_sp_token_uses_configured_broker(monkeypatch):
+    monkeypatch.setenv("CODA_SP_TOKEN_BROKER_URL", "http://127.0.0.1:9/token")
+    monkeypatch.setattr(
+        broker,
+        "urlopen",
+        lambda *_args, **_kwargs: _Response(b"broker-token"),
+    )
+
+    assert broker.fetch_sp_token() == "broker-token"
+
+
+def test_databricks_wrapper_intercepts_only_broker_profile(tmp_path):
+    server = broker.start_sp_token_broker(lambda: "fresh-token", port=0)
+    try:
+        wrapper = write_databricks_token_wrapper(tmp_path, "/usr/bin/false")
+        env = dict(os.environ, CODA_SP_TOKEN_BROKER_URL=broker.broker_url(server))
+        result = subprocess.run(
+            [
+                str(wrapper),
+                "auth",
+                "token",
+                "--profile",
+                "omnigents-host",
+                "--output",
+                "json",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert json.loads(result.stdout) == {"access_token": "fresh-token"}
+
+        delegated = subprocess.run([str(wrapper), "--version"], env=env, check=False)
+        assert delegated.returncode == 1
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class _Response:
+    def __init__(self, body):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self):
+        return self.body

--- a/token_helper.py
+++ b/token_helper.py
@@ -8,21 +8,22 @@ the two agents can never drift apart.
 
 The helper prints exactly one line to stdout: the bearer token. Resolution
 order (see the emitted script's docstring for the full rationale):
-  1. SP OAuth token minted from the ``omnigents-host`` M2M profile (host path).
-  2. The PAT from ``$DATABRICKS_TOKEN`` or ``~/.databrickscfg`` [DEFAULT].
-Both are resolved fresh on each invocation, so a long-running agent survives
+  1. SP OAuth token fetched from the loopback broker (host path).
+  2. Legacy ``omnigents-host`` M2M profile, for upgrades from older containers.
+  3. The PAT from ``$DATABRICKS_TOKEN`` or ``~/.databrickscfg`` [DEFAULT].
+All are resolved fresh on each invocation, so a long-running agent survives
 PAT rotation / SP-OAuth expiry without a restart.
 """
 
 import configparser
+import json
 import os
 import sys
-import json
 from pathlib import Path
 from urllib.request import urlopen
 
-# The SP OAuth profile the Omnigent host writes (auth_type=oauth-m2m). Kept in
-# sync with omnigents_host._HOST_PROFILE and setup_claude._SP_PROFILE.
+# Legacy SP OAuth profile name. New installs persist only a secret-free host
+# pointer under this name and fetch bearers from the loopback broker.
 SP_PROFILE = "omnigents-host"
 
 
@@ -93,7 +94,9 @@ def _sp_oauth_token():
         except Exception:
             pass
 
-    # Mint the SP token via the SDK. The M2M (client_id/secret) profile the
+    # Upgrade fallback: mint via an older persisted M2M profile. New installs
+    # never write client_id/client_secret to terminal-visible HOME.
+    # The M2M (client_id/secret) profile the
     # Omnigent host writes is NOT usable via `databricks auth token` (that CLI
     # verb is U2M-only and refuses M2M); Config.authenticate() does the
     # client-credentials flow. Verified accepted by /anthropic (C-O1, HTTP 200).
@@ -153,7 +156,7 @@ def _pat_token():
 def main():
     token = _sp_oauth_token() or _pat_token()
     if not token:
-        print("no token source (no SP OAuth profile, no PAT)", file=sys.stderr)
+        print("no token source (no SP token broker, no PAT)", file=sys.stderr)
         sys.exit(1)
     sys.stdout.write(token)
 

--- a/token_helper.py
+++ b/token_helper.py
@@ -17,6 +17,7 @@ PAT rotation / SP-OAuth expiry without a restart.
 import configparser
 import os
 import sys
+import json
 from pathlib import Path
 from urllib.request import urlopen
 
@@ -185,3 +186,45 @@ def helper_command(helper_path) -> str:
     """
     py = os.environ.get("CODA_VENV_PYTHON") or sys.executable or "python3"
     return f"!{py} {helper_path}"
+
+
+def write_databricks_token_wrapper(target_dir, real_cli: str) -> Path:
+    """Write a narrow CLI shim for Omnigent's profile-based auth command."""
+    target_dir = Path(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    wrapper_path = target_dir / "databricks"
+    source = f'''#!{sys.executable}
+import json
+import os
+import sys
+from urllib.request import urlopen
+
+REAL_CLI = {json.dumps(real_cli)}
+PROFILE = {json.dumps(SP_PROFILE)}
+
+
+def _profile(args):
+    for index, arg in enumerate(args):
+        if arg == "--profile" and index + 1 < len(args):
+            return args[index + 1]
+        if arg.startswith("--profile="):
+            return arg.split("=", 1)[1]
+    return None
+
+
+args = sys.argv[1:]
+if args[:2] == ["auth", "token"] and _profile(args) == PROFILE:
+    url = os.environ.get("CODA_SP_TOKEN_BROKER_URL", "")
+    with urlopen(url, timeout=5) as response:
+        token = response.read().decode().strip()
+    if "--output" in args and args[args.index("--output") + 1] == "json":
+        print(json.dumps({{"access_token": token}}))
+    else:
+        print(token)
+    raise SystemExit(0)
+
+os.execv(REAL_CLI, [REAL_CLI, *args])
+'''
+    wrapper_path.write_text(source)
+    wrapper_path.chmod(0o700)
+    return wrapper_path


### PR DESCRIPTION
## What does this PR do?

Closes the final Omnigent/auth review gaps:

- keeps the app-SP client secret only in Flask process memory;
- brokers short-lived OAuth tokens on loopback;
- leaves only `host` in `[omnigents-host]`;
- refreshes host and spawned-runner Apps-proxy credentials without persisting a static bearer;
- removes the exposed PAT/personal identifiers and all detected mojibake;
- adds a repeatable Playwright SSO recorder and deployed PTY evidence test.

The spawned-runner refresh hook depends on omnigent-ai/omnigent#2711.

## Automated evidence

- [x] `make test`: **459 passed, 1 skipped**.
- [x] Focused CoDA broker/host suite: **26 passed**.
- [x] Omnigent runner/host modules: **154 passed**.
- [x] Repository mojibake scan clean.
- [x] Exposed PAT revoked (`databricks tokens list --profile daveok` returned `[]`).

## Deployed evidence

Deployed the exact stacked source to Lakemeter app `coding-agents-02`:

- URL: `https://coding-agents-02-335310294452632.aws.databricksapps.com`
- deployment: `01f1832c3f7f19ba8d35442f875a3007` (`SUCCEEDED`)
- Omnigent wheel: `0.6.0.dev0`, commit `43e7fce4`
- host connected as `host_1e70327a2a96b0917d8c2c8ef45694e9`

Playwright drove a real browser PTY and passed in **10.36s**, proving:

- profile keys exactly `["host"]`;
- no client ID, client secret, or static token in the profile;
- no `DATABRICKS_CLIENT_SECRET` in terminal env;
- broker helper and narrow CLI wrapper both return live tokens;
- `café Ελληνικά 日本語 😀` round-trips cleanly with no mojibake markers.

Command:

```bash
DATABRICKS_PROFILE=lakemeter \
CODA_APP_URL=https://coding-agents-02-335310294452632.aws.databricksapps.com \
uv run pytest tests/e2e/test_live_sp_token_broker.py -v -s
```

## Remaining live blocker

A real Omnigent session was created before the runner-auth fix (`conv_baf4e6a67ee0443aaf06c34812aa615a`) and correctly exposed the missing child-runner proxy credential; that defect is now covered and fixed by the dependency change.

After redeploy, the CoDA host repeatedly connected successfully, but Omnigent's browser/API worker returned `404 host not found` for that same live host. This is a server-side process/replica host-registry routing issue, so an Omnigent-launched post-fix agent turn is **not yet claimed as passing**. This PR should remain unmerged until that deployed server routing issue is resolved and the turn is rerun.
