### PR TITLE
fix(tests): scope e2e prerequisite skip to the e2e directory

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -98,8 +98,17 @@ def pytest_collection_modifyitems(config, items):
         )
     if skips:
         skip_marker = pytest.mark.skip(reason=" | ".join(skips))
+        e2e_dir = Path(__file__).parent
         for item in items:
-            item.add_marker(skip_marker)
+            # Only skip items that live in *this* directory. `items` is the
+            # whole session's collection, so an unguarded loop here skips the
+            # entire unit-test suite whenever e2e prerequisites are missing.
+            try:
+                item_path = Path(str(item.fspath)).resolve()
+            except Exception:
+                continue
+            if item_path.is_relative_to(e2e_dir):
+                item.add_marker(skip_marker)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
`pytest_collection_modifyitems` in tests/e2e/conftest.py marked *every* collected test as skipped when the e2e prerequisites were missing, so `uv run pytest tests/` reported "465 skipped" and the CI Tests workflow was passing vacuously. Scoped to items under tests/e2e/. The unit suite now actually runs.