### PR TITLE
fix(mlflow): bound the legacy Claude Stop hook with a timeout

### DIFF
--- a/setup_mlflow.py
+++ b/setup_mlflow.py
@@ -134,7 +134,13 @@ mlflow_hook = {
     "hooks": [
         {
             "type": "command",
-            "command": f"{python_cmd} -c \"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()\""
+            "command": f"{python_cmd} -c \"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()\"",
+            # Bound the hook. On the pinned mlflow (3.14) the handler is a
+            # no-op that returns immediately, but this entry is deliberately
+            # kept for older builds where it processes the entire transcript
+            # synchronously and blocks everything else on the Stop chain.
+            # One dropped trace beats a wedged session.
+            "timeout": 10,
         }
     ]
 }

--- a/tests/test_mlflow_tracing.py
+++ b/tests/test_mlflow_tracing.py
@@ -264,3 +264,29 @@ class TestExperimentPath:
         assert result.returncode == 0
         settings = read_settings(tmp_path)
         assert "jane@company.com" in settings["env"]["MLFLOW_EXPERIMENT_NAME"]
+
+
+class TestStopHookIsBounded:
+    """The legacy Stop hook is retained for mlflow builds older than 3.14, where
+    stop_hook_handler() processes the whole transcript synchronously instead of
+    being a no-op. Claude Code runs Stop hooks in sequence, so an unbounded one
+    stalls everything after it. Cap it: a dropped trace beats a wedged session."""
+
+    def test_stop_hook_declares_a_timeout(self, tmp_path):
+        write_existing_settings(tmp_path, {"env": {}})
+        result = run_setup_mlflow(tmp_path, {"APP_OWNER": "jane@company.com"})
+        assert result.returncode == 0
+
+        stop_hooks = read_settings(tmp_path)["hooks"]["Stop"]
+        mlflow_entries = [
+            h for h in stop_hooks
+            if "stop_hook_handler" in h["hooks"][0].get("command", "")
+        ]
+        assert mlflow_entries, "expected the mlflow Stop hook to be registered"
+        for entry in mlflow_entries:
+            hook = entry["hooks"][0]
+            assert "timeout" in hook, (
+                "the mlflow Stop hook must declare a timeout — without one it can "
+                "block the rest of the Stop chain indefinitely on mlflow < 3.14"
+            )
+            assert 0 < hook["timeout"] <= 60


### PR DESCRIPTION
Replaces #109 (stale merge base after the squash-merge batch).

The legacy Stop hook is deliberately still registered for mlflow builds older than 3.14, where `stop_hook_handler()` processes the entire transcript synchronously rather than being a no-op. Claude Code runs Stop hooks **in sequence**, so an unbounded one stalls everything queued behind it. Capped at 10s — a dropped trace beats a wedged session.

Carried forward from #15, whose approach is otherwise superseded: main drives tracing through the `mlflow autolog claude` plugin gated on `MLFLOW_TRACING_ENABLED`, and the hook script #15 referenced lives in #17's `coda-marketplace` tree.

**Scope:** 2 files, +33/-1. Test verified to fail without the change.

⚠️ Not deploy-verified (see #108 discussion) — but the change is a single JSON field in a hook config, and `setup_mlflow.py` has unit coverage.