### PR TITLE
fix(reliability): make app-owner resolution recoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,9 @@ Open [http://localhost:8000](http://localhost:8000) — type `claude`, `codex`, 
 | `HERMES_MODEL` | No | Hermes model name (default: `databricks-claude-opus-4-6`) |
 | `HERMES_FALLBACK_MODEL` | No | Fallback model if `HERMES_MODEL` is unavailable in this workspace's geo |
 | `ENABLE_HERMES` | No | Set to `"false"` to skip Hermes Agent install. Other CLIs are unaffected. Default `"true"` |
+| `APP_OWNER_EMAIL` | No | Pin the app owner instead of resolving it from the Apps API. Useful when the app is created *on behalf of* someone (so `app.creator` is the wrong identity), or to remove the boot-time API call from the critical path entirely. Authorization fails closed while the owner is unresolved, so this is the deterministic escape hatch |
+| `FLASK_SECRET_KEY` | No | Signs session cookies. Unset = a fresh random key per worker start, which invalidates existing sessions on every restart. Wire to a Databricks secret in production |
+| `CODA_TELEMETRY_DISABLED` | No | Set to `"true"` to make `log_telemetry()` a no-op — no outbound telemetry to disclose in a third-party-risk review |
 | `MAX_CONCURRENT_SESSIONS` | No | Cap on simultaneous PTY sessions per worker (default `5`) |
 | `CLAUDE_CODE_DISABLE_AUTO_MEMORY` | No | Pass-through to Claude Code's auto-memory feature (default `0`) |
 | `MLFLOW_TRACING_ENABLED` | No | Set to `"true"` to enable MLflow tracing for Claude, Codex, and Gemini in one switch (default `"false"`) |

--- a/app.py
+++ b/app.py
@@ -170,6 +170,7 @@ setup_state = {
     "steps": [
         {"id": "git",        "label": "Configuring git identity",     "status": "pending", "started_at": None, "completed_at": None, "error": None},
         {"id": "micro",      "label": "Installing micro editor",      "status": "pending", "started_at": None, "completed_at": None, "error": None},
+        {"id": "editors",    "label": "Detecting available editors",  "status": "pending", "started_at": None, "completed_at": None, "error": None},
         {"id": "gh",         "label": "Installing GitHub CLI",        "status": "pending", "started_at": None, "completed_at": None, "error": None},
         {"id": "dbcli",     "label": "Upgrading Databricks CLI",     "status": "pending", "started_at": None, "completed_at": None, "error": None},
         {"id": "proxy",   "label": "Starting content-filter proxy", "status": "pending", "started_at": None, "completed_at": None, "error": None},
@@ -181,6 +182,7 @@ setup_state = {
         {"id": "hermes",     "label": "Configuring Hermes Agent",     "status": "pending", "started_at": None, "completed_at": None, "error": None},
         {"id": "databricks", "label": "Setting up Databricks CLI",    "status": "pending", "started_at": None, "completed_at": None, "error": None},
         {"id": "mlflow",     "label": "Enabling MLflow tracing",       "status": "pending", "started_at": None, "completed_at": None, "error": None},
+        {"id": "projects",   "label": "Setting up bundled projects",   "status": "pending", "started_at": None, "completed_at": None, "error": None},
     ]
 }
 
@@ -501,6 +503,17 @@ def _setup_git_config():
         f.write("\n".join(lines) + "\n")
     logger.info(f"Git config written to {gitconfig_path}")
 
+    # Configure gh as git's credential helper so `git push` works without the
+    # user wiring credentials by hand. gh must be authenticated (GH_TOKEN, or
+    # `gh auth login` in the terminal) for the helper to actually supply
+    # anything — this only installs the plumbing.
+    try:
+        subprocess.run(["gh", "auth", "setup-git"], capture_output=True, timeout=10)
+        logger.info("gh auth setup-git configured")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        # gh is installed later in run_setup(); absent at first boot is normal.
+        logger.debug("gh not available, skipping credential helper setup")
+
     # Write post-commit hook for workspace sync (works from any CLI: Claude, Gemini, OpenCode, etc.)
     # Only syncs repos inside ~/projects/ — skips the app source and any other repos
     post_commit = os.path.join(hooks_dir, "post-commit")
@@ -547,8 +560,90 @@ def _setup_git_config():
     os.chmod(post_commit, 0o755)
     logger.info(f"Post-commit hook written to {post_commit}")
 
+    # `wsync` — manual workspace sync for the current repo. The post-commit hook
+    # above covers the normal path; this is the recovery path for when a commit's
+    # sync failed (see ~/.sync.log) and you don't want an empty commit to retry.
+    local_bin = os.path.join(home, ".local", "bin")
+    os.makedirs(local_bin, exist_ok=True)
+    wsync_path = os.path.join(local_bin, "wsync")
+    with open(wsync_path, "w") as f:
+        f.write(
+            '#!/bin/bash\n'
+            '# Manually sync the current git repo to the Databricks Workspace.\n'
+            'set -euo pipefail\n'
+            'REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"\n'
+            'if [ -z "$REPO_ROOT" ]; then\n'
+            '    echo "Error: not inside a git repo" >&2\n'
+            '    exit 1\n'
+            'fi\n'
+            'APP_DIR="/app/python/source_code"\n'
+            'SYNC_SCRIPT="$APP_DIR/sync_to_workspace.py"\n'
+            'if [ ! -f "$SYNC_SCRIPT" ]; then\n'
+            '    echo "Error: sync script not found at $SYNC_SCRIPT" >&2\n'
+            '    exit 1\n'
+            'fi\n'
+            'echo "Syncing $REPO_ROOT to Databricks Workspace..."\n'
+            'uv run --project "$APP_DIR" python "$SYNC_SCRIPT" "$REPO_ROOT"\n'
+        )
+    os.chmod(wsync_path, 0o755)
+    logger.info(f"wsync command written to {wsync_path}")
+
     # Reinit app source git to remove template origin (Databricks Apps only)
     _reinit_app_git()
+
+
+def _setup_bundled_projects():
+    """Copy project templates bundled with the app source into ~/projects/.
+
+    Anything under <app_source>/projects/<name>/ is copied to ~/projects/<name>/
+    (skipped if already present) and git-init'd, so the post-commit hook picks it
+    up and commits sync to the Workspace — which is the only durable backup in
+    this ephemeral container.
+
+    No-op when the app ships no `projects/` directory, which is the default.
+    """
+    import shutil
+
+    app_dir = os.path.dirname(os.path.abspath(__file__))
+    bundled_dir = os.path.join(app_dir, "projects")
+    if not os.path.isdir(bundled_dir):
+        return
+
+    home = os.environ.get("HOME", "/app/python/source_code")
+    if not home or home == "/":
+        home = "/app/python/source_code"
+    projects_dir = os.path.join(home, "projects")
+    os.makedirs(projects_dir, exist_ok=True)
+
+    for name in sorted(os.listdir(bundled_dir)):
+        src = os.path.join(bundled_dir, name)
+        if not os.path.isdir(src):
+            continue
+        dest = os.path.join(projects_dir, name)
+        if os.path.exists(dest):
+            logger.info(f"Bundled project already present, skipping: {dest}")
+            continue
+
+        shutil.copytree(src, dest)
+        # git init so the post-commit workspace-sync hook applies here too.
+        subprocess.run(["git", "init"], cwd=dest, capture_output=True)
+        subprocess.run(["git", "add", "."], cwd=dest, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit from bundled project"],
+            cwd=dest, capture_output=True,
+        )
+        logger.info(f"Bundled project initialized: {dest}")
+
+
+def _run_projects_step():
+    """Run bundled-project setup as a tracked setup step."""
+    _update_step("projects", status="running", started_at=time.time())
+    try:
+        _setup_bundled_projects()
+        _update_step("projects", status="complete", completed_at=time.time())
+    except Exception as e:
+        logger.warning(f"Bundled project setup failed: {e}")
+        _update_step("projects", status="error", completed_at=time.time(), error=str(e))
 
 
 def _reinit_app_git():
@@ -683,6 +778,22 @@ def run_setup():
     _run_step("micro", ["bash", "-c",
         "mkdir -p ~/.local/bin && bash install_micro.sh && mv micro ~/.local/bin/ 2>/dev/null || true"])
 
+    # Probe which terminal editors actually exist in this container. The runtime
+    # image's editor set is not guaranteed, and "which editor can I use?" is a
+    # recurring first question — for humans and for agents driving the terminal.
+    # Report lands at ~/.local/share/coda/editors.txt.
+    # Note the `|| true` on the probe: `command -v` returns non-zero for a
+    # missing editor, and without it the loop's exit status is the *last*
+    # probe's. Since `mcedit` is absent on the standard image, the whole step
+    # would exit 1 and be reported as an error on every single boot.
+    _run_step("editors", ["bash", "-c",
+        "mkdir -p ~/.local/share/coda && "
+        "{ echo 'Available terminal editors (detected at app startup):'; "
+        "  for ed in micro nano vim vi emacs ed pico joe mcedit; do "
+        "    p=$(command -v \"$ed\" 2>/dev/null) && echo \"  $ed -> $p\" || true; "
+        "  done; } > ~/.local/share/coda/editors.txt && "
+        "cat ~/.local/share/coda/editors.txt"])
+
     _run_step("gh", ["bash", "install_gh.sh"])
 
 
@@ -710,11 +821,14 @@ def run_setup():
         ("databricks", [_py, "setup_databricks.py"]),
     ]
 
-    with ThreadPoolExecutor(max_workers=len(parallel_steps)) as executor:
+    with ThreadPoolExecutor(max_workers=len(parallel_steps) + 1) as executor:
         futures = [
             executor.submit(_run_step, step_id, command)
             for step_id, command in parallel_steps
         ]
+        # Bundled projects (copy + git init) — no network, runs alongside the
+        # agent installs rather than adding to the critical path.
+        futures.append(executor.submit(_run_projects_step))
         wait(futures)
 
     # --- MLflow setup runs AFTER claude setup to avoid settings.json race ---
@@ -740,26 +854,136 @@ def run_setup():
         setup_state["completed_at"] = time.time()
 
 
-def get_token_owner():
-    """Get the owner email. Priority: Apps API (app.creator) > PAT (current_user.me).
+# Boot-time owner resolution is bounded so it can't stall gunicorn binding the
+# port (initialize_app runs before that). A transient failure is recovered by the
+# background retry thread below rather than by a longer boot stall.
+_OWNER_BOOT_ATTEMPTS = 3
+_OWNER_BOOT_BASE_DELAY = 2.0
+# The background retry keeps going for a while — the failure mode it exists for
+# (app-SP credentials not yet usable for OAuth exchange) resolves in seconds to
+# minutes, and until it does, check_authorization() fails closed and the app is
+# unusable.
+_OWNER_RETRY_ATTEMPTS = 8
+_OWNER_RETRY_MAX_DELAY = 60
 
-    Uses the auto-provisioned SP to call the Apps API — no PAT needed for
-    owner resolution. Falls back to PAT-based lookup for backward compat.
+
+def _owner_from_apps_api():
+    """Resolve the owner via the Apps API using the app's own SP credentials.
+
+    Returns the lowercased email, or None if the call failed. Prefers the
+    spawner's `owner:{email}` description over `app.creator`: when one identity
+    creates apps on behalf of others, `creator` is the spawner, not the user who
+    should own the box.
     """
     from databricks.sdk import WorkspaceClient
 
-    # 1. Try Apps API via SP credentials (no PAT needed)
     app_name = os.environ.get("DATABRICKS_APP_NAME")
-    if app_name:
-        try:
-            w = WorkspaceClient()  # auto-detects SP credentials
-            set_product_info(w)
-            app = w.apps.get(name=app_name)
-            owner = (app.creator or "").lower()
-            logger.info(f"Owner resolved from app.creator: {owner}")
+    if not app_name:
+        return None
+
+    w = WorkspaceClient()  # auto-detects SP credentials
+    set_product_info(w)
+    app_info = w.apps.get(name=app_name)
+
+    description = getattr(app_info, "description", "") or ""
+    if description.startswith("owner:"):
+        owner = description.split(":", 1)[1].strip().lower()
+        if owner:
+            logger.info(f"Owner resolved from app description: {owner}")
             return owner
-        except Exception as e:
-            logger.warning(f"Could not resolve owner via Apps API: {e}")
+
+    owner = (app_info.creator or "").lower()
+    if owner:
+        logger.info(f"Owner resolved from app.creator: {owner}")
+        return owner
+    return None
+
+
+def _retry_owner_resolution_in_background():
+    """Keep trying to resolve the owner after a failed boot-time attempt.
+
+    check_authorization() fails CLOSED when app_owner is unresolved, so a
+    transient Apps-API failure at boot would otherwise brick the app until
+    someone restarted it. Retrying in a daemon thread lets the app self-heal
+    without delaying the port bind.
+    """
+    def _retry():
+        global app_owner
+        for attempt in range(_OWNER_RETRY_ATTEMPTS):
+            delay = min(_OWNER_BOOT_BASE_DELAY * (2 ** attempt), _OWNER_RETRY_MAX_DELAY)
+            time.sleep(delay)
+            if app_owner:
+                return  # resolved elsewhere (e.g. a PAT was configured)
+            try:
+                owner = _owner_from_apps_api()
+            except Exception as e:
+                logger.warning(
+                    f"Background owner resolution attempt {attempt + 1}"
+                    f"/{_OWNER_RETRY_ATTEMPTS} failed: {e}"
+                )
+                continue
+            if owner:
+                app_owner = owner
+                os.environ["APP_OWNER"] = owner
+                try:
+                    app_state.set_app_owner(owner)
+                except Exception as e:
+                    logger.warning(f"Could not persist recovered owner: {e}")
+                logger.info(f"App owner recovered in background: {owner}")
+                return
+        logger.error(
+            "Owner resolution never succeeded — the app stays fail-closed. "
+            "Set APP_OWNER_EMAIL in app.yaml to resolve the owner without an "
+            "Apps API call."
+        )
+
+    threading.Thread(target=_retry, daemon=True, name="owner-resolve-retry").start()
+
+
+def get_token_owner():
+    """Get the owner email.
+
+    Priority: APP_OWNER_EMAIL env var > Apps API (spawner description, then
+    app.creator) > PAT (current_user.me).
+
+    The Apps API path uses the auto-provisioned SP, so it needs no PAT. It is
+    retried a few times because the SP's credentials are not always usable for
+    OAuth token exchange the instant the container starts — but only briefly,
+    since this runs before gunicorn binds the port. APP_OWNER_EMAIL skips the
+    call entirely and is the deterministic escape hatch when the API is
+    unreliable or the creator isn't the intended owner.
+    """
+    from databricks.sdk import WorkspaceClient
+
+    # 0. Explicit owner from the deployer — no API call, cannot fail.
+    explicit_owner = os.environ.get("APP_OWNER_EMAIL", "").strip().lower()
+    if explicit_owner:
+        logger.info(f"Owner resolved from APP_OWNER_EMAIL: {explicit_owner}")
+        return explicit_owner
+
+    # 1. Try Apps API via SP credentials (no PAT needed), bounded retry.
+    if os.environ.get("DATABRICKS_APP_NAME"):
+        for attempt in range(_OWNER_BOOT_ATTEMPTS):
+            try:
+                owner = _owner_from_apps_api()
+                if owner:
+                    return owner
+                logger.warning("Apps API returned no owner for this app")
+                break
+            except Exception as e:
+                last = attempt == _OWNER_BOOT_ATTEMPTS - 1
+                if last:
+                    logger.warning(
+                        f"Could not resolve owner via Apps API after "
+                        f"{_OWNER_BOOT_ATTEMPTS} attempts: {e}"
+                    )
+                else:
+                    delay = _OWNER_BOOT_BASE_DELAY * (2 ** attempt)
+                    logger.warning(
+                        f"Apps API call failed (attempt {attempt + 1}"
+                        f"/{_OWNER_BOOT_ATTEMPTS}): {e} — retrying in {delay:.0f}s"
+                    )
+                    time.sleep(delay)
 
     # 2. Fallback: PAT-based resolution
     try:
@@ -1961,7 +2185,15 @@ def initialize_app(local_dev=False):
         os.environ["APP_OWNER"] = app_owner
         app_state.set_app_owner(app_owner)
     else:
-        logger.warning("Could not determine app owner - authorization disabled")
+        # check_authorization() fails CLOSED on Databricks Apps when app_owner is
+        # unresolved, so this is not "authorization disabled" — it's "nobody can
+        # use the app". Keep trying in the background so a transient Apps-API
+        # failure at boot doesn't require a manual restart.
+        logger.error(
+            "Could not determine app owner — access stays denied (fail-closed) "
+            "until resolution succeeds"
+        )
+        _retry_owner_resolution_in_background()
 
     sp_helper_enabled = os.environ.get("ENABLE_SP_APIKEYHELPER", "").strip().lower() in (
         "true", "1", "yes",

--- a/tests/test_owner_resolution.py
+++ b/tests/test_owner_resolution.py
@@ -1,0 +1,193 @@
+"""Tests for app-owner resolution.
+
+Why this matters more than it looks: `check_authorization()` fails **closed** on
+Databricks Apps when `app_owner` is unresolved. So a transient Apps-API failure
+during `initialize_app()` doesn't degrade to "authorization disabled" — it makes
+the app unusable for everyone until someone restarts it.
+
+Three properties are covered here:
+
+1. `APP_OWNER_EMAIL` short-circuits the API entirely (deterministic escape hatch).
+2. The Apps API path prefers the spawner's `owner:{email}` description over
+   `app.creator`, because when one identity creates apps for other people the
+   creator is the spawner, not the intended owner.
+3. Boot-time retry is *bounded* — `initialize_app()` runs before gunicorn binds
+   the port, so a long backoff there stalls the whole app's startup. Unbounded
+   recovery happens on a background thread instead.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+@pytest.fixture
+def app_module():
+    import app
+
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("APP_OWNER_EMAIL", raising=False)
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "coda-test")
+    # Keep the PAT fallback from firing and making real calls.
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+    monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+
+
+class TestExplicitOwner:
+    def test_app_owner_email_wins_without_any_api_call(self, app_module, monkeypatch):
+        monkeypatch.setenv("APP_OWNER_EMAIL", "Owner@Example.COM")
+
+        with mock.patch.object(app_module, "_owner_from_apps_api") as api:
+            assert app_module.get_token_owner() == "owner@example.com"
+
+        api.assert_not_called()
+
+    def test_blank_app_owner_email_is_ignored(self, app_module, monkeypatch):
+        monkeypatch.setenv("APP_OWNER_EMAIL", "   ")
+
+        with mock.patch.object(
+            app_module, "_owner_from_apps_api", return_value="creator@example.com"
+        ):
+            assert app_module.get_token_owner() == "creator@example.com"
+
+
+class TestAppsApiResolution:
+    def _client(self, *, creator=None, description=None):
+        app_info = SimpleNamespace(creator=creator, description=description)
+        return SimpleNamespace(apps=SimpleNamespace(get=lambda name: app_info))
+
+    def _patch_sdk(self, app_module, client):
+        # get_token_owner imports WorkspaceClient lazily from databricks.sdk.
+        return mock.patch("databricks.sdk.WorkspaceClient", return_value=client)
+
+    def test_spawner_description_takes_precedence_over_creator(self, app_module):
+        client = self._client(
+            creator="spawner-sp@example.com", description="owner:Real.User@example.com"
+        )
+        with self._patch_sdk(app_module, client), \
+             mock.patch.object(app_module, "set_product_info"):
+            assert app_module._owner_from_apps_api() == "real.user@example.com"
+
+    def test_falls_back_to_creator(self, app_module):
+        client = self._client(creator="Creator@Example.com", description="some app")
+        with self._patch_sdk(app_module, client), \
+             mock.patch.object(app_module, "set_product_info"):
+            assert app_module._owner_from_apps_api() == "creator@example.com"
+
+    def test_empty_owner_description_falls_through_to_creator(self, app_module):
+        client = self._client(creator="creator@example.com", description="owner:")
+        with self._patch_sdk(app_module, client), \
+             mock.patch.object(app_module, "set_product_info"):
+            assert app_module._owner_from_apps_api() == "creator@example.com"
+
+    def test_returns_none_when_nothing_identifies_an_owner(self, app_module):
+        client = self._client(creator=None, description=None)
+        with self._patch_sdk(app_module, client), \
+             mock.patch.object(app_module, "set_product_info"):
+            assert app_module._owner_from_apps_api() is None
+
+    def test_no_app_name_means_no_api_attempt(self, app_module, monkeypatch):
+        monkeypatch.delenv("DATABRICKS_APP_NAME", raising=False)
+        assert app_module._owner_from_apps_api() is None
+
+
+class TestBootRetryIsBounded:
+    def test_retries_then_gives_up_without_blocking_boot(self, app_module):
+        """A flaky API must not turn the port bind into a multi-minute wait."""
+        calls = []
+
+        def boom():
+            calls.append(1)
+            raise RuntimeError("SP credentials not ready")
+
+        with mock.patch.object(app_module, "_owner_from_apps_api", side_effect=boom), \
+             mock.patch.object(app_module.time, "sleep") as sleep:
+            result = app_module.get_token_owner()
+
+        assert result is None
+        assert len(calls) == app_module._OWNER_BOOT_ATTEMPTS
+        # One fewer sleep than attempts — no pointless wait after the last try.
+        assert sleep.call_count == app_module._OWNER_BOOT_ATTEMPTS - 1
+        total_boot_delay = sum(c.args[0] for c in sleep.call_args_list)
+        assert total_boot_delay <= 30, (
+            f"boot-time owner resolution would stall gunicorn for "
+            f"{total_boot_delay}s before binding the port"
+        )
+
+    def test_transient_failure_then_success(self, app_module):
+        attempts = [RuntimeError("not ready"), "owner@example.com"]
+
+        def flaky():
+            value = attempts.pop(0)
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+        with mock.patch.object(app_module, "_owner_from_apps_api", side_effect=flaky), \
+             mock.patch.object(app_module.time, "sleep"):
+            assert app_module.get_token_owner() == "owner@example.com"
+
+    def test_no_retry_when_api_answers_with_no_owner(self, app_module):
+        """An authoritative "this app has no owner" isn't worth retrying."""
+        with mock.patch.object(
+            app_module, "_owner_from_apps_api", return_value=None
+        ) as api, mock.patch.object(app_module.time, "sleep"):
+            app_module.get_token_owner()
+
+        assert api.call_count == 1
+
+
+class TestBackgroundRecovery:
+    def test_recovers_owner_and_publishes_it(self, app_module, monkeypatch):
+        """The whole point: the app self-heals instead of staying fail-closed
+        until a human notices and restarts it."""
+        monkeypatch.setattr(app_module, "app_owner", None, raising=False)
+        # setenv (not delenv) so monkeypatch tracks the key and restores it at
+        # teardown — the code under test writes os.environ directly, which
+        # monkeypatch cannot see.
+        monkeypatch.setenv("APP_OWNER", "")
+
+        threads = []
+
+        def run_immediately(target=None, daemon=None, name=None):
+            threads.append(target)
+            return SimpleNamespace(start=target)
+
+        with mock.patch.object(app_module.threading, "Thread", run_immediately), \
+             mock.patch.object(app_module.time, "sleep"), \
+             mock.patch.object(
+                 app_module, "_owner_from_apps_api", return_value="owner@example.com"
+             ), \
+             mock.patch.object(app_module.app_state, "set_app_owner") as persist:
+            app_module._retry_owner_resolution_in_background()
+
+        assert app_module.app_owner == "owner@example.com"
+        assert app_module.os.environ["APP_OWNER"] == "owner@example.com"
+        persist.assert_called_once_with("owner@example.com")
+
+    def test_stops_early_if_owner_resolved_elsewhere(self, app_module, monkeypatch):
+        """A PAT configured in the UI can resolve the owner first; the retry
+        thread must not then overwrite it or keep hammering the API."""
+        monkeypatch.setattr(app_module, "app_owner", "already@example.com", raising=False)
+
+        def run_immediately(target=None, daemon=None, name=None):
+            return SimpleNamespace(start=target)
+
+        with mock.patch.object(app_module.threading, "Thread", run_immediately), \
+             mock.patch.object(app_module.time, "sleep"), \
+             mock.patch.object(app_module, "_owner_from_apps_api") as api:
+            app_module._retry_owner_resolution_in_background()
+
+        api.assert_not_called()
+        assert app_module.app_owner == "already@example.com"


### PR DESCRIPTION
Replaces #108 (stale merge base after the squash-merge batch — its diff had picked up ~3,000 deletions of content already on main).

## The problem

`check_authorization()` fails **closed** when `app_owner` is unresolved. So a transient Apps-API failure during `initialize_app()` doesn't mean 'authorization disabled' — it means **nobody can use the app** until someone restarts it. The old log line said the former, which is misleading.

## Changes

- `APP_OWNER_EMAIL` short-circuits the API entirely — deterministic escape hatch.
- The spawner's `owner:{email}` app description is preferred over `app.creator`, which is the *spawner's* identity when apps are created on behalf of users.
- Boot-time retry **bounded** to 3 attempts (~6s). #19 proposed 6 attempts with a 60s cap (~135s), but `initialize_app()` runs *before* gunicorn binds the port — that trades one failure mode for a boot stall.
- Unbounded recovery moved to a background daemon thread, so the app self-heals without delaying the bind.

Also carried from #19: `gh auth setup-git`, a `wsync` command for when a commit's workspace sync failed, an editors probe at `~/.local/share/coda/editors.txt`, and bundled-project setup.

> #19's editors probe was broken: `command -v` returns non-zero for a missing editor, so the group's exit status was the *last* probe's — and `mcedit` isn't on the image, so the step would have reported an error on **every boot**. Fixed with `|| true`.

## Not taken from #19

It downgraded the version 0.18.1→0.17.1, lowered the `cryptography` floor (a CVE fix), swapped the protected runner for `ubuntu-latest`, un-pinned `setup-uv`, and stretched PAT lifetime to 4h/3h.

## Verification

12 new tests in `tests/test_owner_resolution.py` covering precedence, the bounded boot retry, and background recovery. 513 tests pass.

⚠️ **Not deploy-verified.** This changes boot behaviour on an auth-critical path that fails closed. I'd recommend deploying to a workspace and confirming owner resolution + `/api/setup-status` before merging this one.