### PR TITLE
fix(opencode): write auth.json in opencode's real schema + proxy fixes for Gemini/GPT

### DIFF
--- a/cli_auth.py
+++ b/cli_auth.py
@@ -16,6 +16,7 @@ import stat
 import logging
 
 from claude_otel import refresh_claude_otel_token
+from utils import OPENCODE_AUTH_KEY_FIELD, is_opencode_api_credential
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +121,13 @@ def _update_codex(token):
 
 
 def _update_opencode(token):
-    """Update api_key values in ~/.local/share/opencode/auth.json."""
+    """Rotate API keys in ~/.local/share/opencode/auth.json.
+
+    The credential shape is defined once in utils — shared with the writer in
+    setup_opencode.py so the two can't drift. Only `type == "api"` entries are
+    touched; `oauth` and `wellknown` credentials carry different fields and must
+    not have a PAT written into them.
+    """
     path = os.path.join(_HOME, ".local", "share", "opencode", "auth.json")
     if not os.path.exists(path):
         return  # setup_opencode.py hasn't run yet
@@ -129,8 +136,8 @@ def _update_opencode(token):
             auth = json.load(f)
         changed = False
         for provider in auth.values():
-            if isinstance(provider, dict) and "api_key" in provider:
-                provider["api_key"] = token
+            if is_opencode_api_credential(provider):
+                provider[OPENCODE_AUTH_KEY_FIELD] = token
                 changed = True
         if changed:
             _atomic_write_text(path, json.dumps(auth, indent=2))

--- a/content_filter_proxy.py
+++ b/content_filter_proxy.py
@@ -138,11 +138,24 @@ if not log.handlers:
 # JSON Schema keywords that Gemini doesn't support
 GEMINI_UNSUPPORTED_SCHEMA_KEYS = {
     "$schema", "$ref", "$defs", "$id", "$comment", "additionalProperties",
+    # Numeric/array validation keywords Gemini's function-declaration schema
+    # doesn't accept. Sending them yields a 400 on the whole request, so the
+    # tool is unusable rather than merely unvalidated.
+    "exclusiveMinimum", "exclusiveMaximum", "multipleOf", "uniqueItems",
 }
 
 # Top-level request fields that Gemini doesn't support
 GEMINI_UNSUPPORTED_REQUEST_KEYS = {
     "stream_options",
+}
+
+# Reasoning controls that only the GPT family accepts. Stripped for GPT-routed
+# requests where the served endpoint rejects them; deliberately NOT stripped
+# globally, because removing them from a model that *does* support reasoning
+# silently downgrades its output quality.
+GPT_REASONING_KEYS = {
+    "reasoningSummary",
+    "reasoning_effort",
 }
 
 
@@ -153,28 +166,34 @@ GEMINI_UNSUPPORTED_REQUEST_KEYS = {
 def strip_unsupported_schema_keys(obj):
     """Recursively strip JSON Schema keywords that Gemini doesn't support."""
     if isinstance(obj, dict):
-        return {
+        cleaned = {
             k: strip_unsupported_schema_keys(v)
             for k, v in obj.items()
             if k not in GEMINI_UNSUPPORTED_SCHEMA_KEYS
         }
+        # Gemini rejects range bounds on integer-typed properties specifically.
+        if cleaned.get("type") == "integer":
+            cleaned.pop("minimum", None)
+            cleaned.pop("maximum", None)
+        return cleaned
     elif isinstance(obj, list):
         return [strip_unsupported_schema_keys(item) for item in obj]
     return obj
 
 
 def sanitize_tool_schemas(data):
-    """Strip JSON Schema keywords that some providers reject.
+    """Strip request fields and JSON Schema keywords that providers reject.
 
-    Applied universally — $schema, additionalProperties etc. are never
-    required by any downstream API. Claude/GPT ignore them, Gemini rejects them.
-    Stripping for all models is safe and avoids model detection issues.
+    Schema stripping is applied universally — $schema, additionalProperties etc.
+    are never required by any downstream API. Claude/GPT ignore them, Gemini
+    rejects them. Stripping for all models is safe and avoids model detection.
+
+    Note there is deliberately NO early return for tool-less requests. There used
+    to be one, which meant the top-level cleanup below (stream_options, $schema,
+    and the GPT reasoning keys) silently never ran for any request without
+    `tools` — i.e. every plain chat turn.
     """
-    tools = data.get("tools", [])
-    if not tools:
-        return data
-
-    for tool in tools:
+    for tool in data.get("tools", []) or []:
         func = tool.get("function", {})
         if "parameters" in func:
             func["parameters"] = strip_unsupported_schema_keys(func["parameters"])
@@ -184,6 +203,15 @@ def sanitize_tool_schemas(data):
         if key in data:
             log.info(f"  Stripped top-level field: {key}")
             del data[key]
+
+    # GPT-only reasoning controls. Scoped by model id rather than applied
+    # globally so reasoning-capable models keep their settings.
+    model = (data.get("model") or "").lower()
+    if "gpt" in model:
+        for key in GPT_REASONING_KEYS:
+            if key in data:
+                log.info(f"  Stripped GPT reasoning field: {key} (model={model})")
+                del data[key]
 
     # Strip $schema from top level if present
     data.pop("$schema", None)
@@ -413,14 +441,36 @@ def remap_tool_call(tool_call):
     return tool_call
 
 
+def _flatten_content_blocks(content):
+    """Collapse an Anthropic-style content array into a plain string.
+
+    Some served models answer chat-completions requests with `content` as a list
+    of typed blocks (`[{"type": "text", "text": "..."}]`) instead of a string.
+    OpenAI-shaped clients like OpenCode expect a string and render the raw list
+    (or drop the message) when handed an array. Non-list input passes through, so
+    this is a no-op for well-behaved responses.
+    """
+    if not isinstance(content, list):
+        return content
+    parts = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "".join(parts)
+
+
 def fix_response_data(data):
-    """Fix tool names and finish_reason in a parsed response object."""
+    """Fix tool names, finish_reason, and content-block arrays in a response."""
     if not isinstance(data, dict):
         return data
 
     for choice in data.get("choices", []):
         # Non-streaming: choice.message
         message = choice.get("message", {})
+        if "content" in message:
+            message["content"] = _flatten_content_blocks(message["content"])
         tool_calls = message.get("tool_calls", [])
         if tool_calls:
             message["tool_calls"] = [remap_tool_call(tc) for tc in tool_calls]
@@ -430,6 +480,8 @@ def fix_response_data(data):
 
         # Streaming: choice.delta
         delta = choice.get("delta", {})
+        if "content" in delta:
+            delta["content"] = _flatten_content_blocks(delta["content"])
         delta_tool_calls = delta.get("tool_calls", [])
         if delta_tool_calls:
             delta["tool_calls"] = [remap_tool_call(tc) for tc in delta_tool_calls]

--- a/setup_opencode.py
+++ b/setup_opencode.py
@@ -19,6 +19,7 @@ from utils import (
     ensure_https,
     get_gateway_host,
     get_npm_version,
+    opencode_api_credential,
     pick_in_geo_model,
 )
 from enterprise_config import npm_env
@@ -263,24 +264,23 @@ config_path.write_text(json.dumps(opencode_config, indent=2))
 print(f"OpenCode configured: {config_path}")
 
 # 4. Also create auth credentials for the databricks provider(s)
-# OpenCode stores credentials at ~/.local/share/opencode/auth.json
+# OpenCode stores credentials at ~/.local/share/opencode/auth.json.
+#
+# The credential shape lives in utils.opencode_api_credential() — shared with
+# cli_auth._update_opencode(), which rotates the same field every 10 minutes.
+# See the comment there for why: both sides previously wrote `api_key`, which
+# opencode does not recognise.
 opencode_data_dir = home / ".local" / "share" / "opencode"
 opencode_data_dir.mkdir(parents=True, exist_ok=True)
 
 if gateway_host:
     auth_data = {
-        "databricks": {
-            "api_key": gateway_token
-        },
-        "databricks-openai": {
-            "api_key": gateway_token
-        }
+        "databricks": opencode_api_credential(gateway_token),
+        "databricks-openai": opencode_api_credential(gateway_token),
     }
 else:
     auth_data = {
-        "databricks": {
-            "api_key": token
-        }
+        "databricks": opencode_api_credential(token),
     }
 
 auth_path = opencode_data_dir / "auth.json"

--- a/tests/test_cli_token_rotation.py
+++ b/tests/test_cli_token_rotation.py
@@ -147,18 +147,77 @@ class TestUpdateCodex:
 
 
 class TestUpdateOpenCode:
-    def test_updates_api_key_in_auth_json(self, isolated_home):
+    """opencode's auth.json is a map of provider-id -> credential, where the
+    credential is a discriminated union on `type`. The API-key variant keeps the
+    secret in `key`:
+
+        export class Api extends Schema.Class<Api>("ApiAuth")({
+            type: Schema.Literal("api"),
+            key: Schema.String,
+            ...
+
+    (packages/opencode/src/auth/index.ts). `api_key` is not a field opencode
+    recognises — these tests previously asserted that shape, which is how the
+    mismatch survived: setup_opencode.py wrote `api_key` and the rotator
+    faithfully rotated a field opencode never reads.
+    """
+
+    def test_rotates_key_for_api_credentials(self, isolated_home):
         from cli_auth import update_cli_tokens
         auth_dir = isolated_home / ".local" / "share" / "opencode"
         auth_dir.mkdir(parents=True)
-        auth = {"databricks": {"api_key": "old"}, "databricks-openai": {"api_key": "old"}}
+        auth = {
+            "databricks": {"type": "api", "key": "old"},
+            "databricks-openai": {"type": "api", "key": "old"},
+        }
         (auth_dir / "auth.json").write_text(json.dumps(auth))
 
         update_cli_tokens("new-token")
 
         result = json.loads((auth_dir / "auth.json").read_text())
-        assert result["databricks"]["api_key"] == "new-token"
-        assert result["databricks-openai"]["api_key"] == "new-token"
+        assert result["databricks"]["key"] == "new-token"
+        assert result["databricks-openai"]["key"] == "new-token"
+        # `type` is the union discriminant — rotation must preserve it.
+        assert result["databricks"]["type"] == "api"
+
+    def test_leaves_non_api_credentials_alone(self, isolated_home):
+        """oauth / wellknown credentials have different fields. Writing a PAT
+        into them would corrupt a credential opencode still needs."""
+        from cli_auth import update_cli_tokens
+        auth_dir = isolated_home / ".local" / "share" / "opencode"
+        auth_dir.mkdir(parents=True)
+        auth = {
+            "databricks": {"type": "api", "key": "old"},
+            "anthropic": {
+                "type": "oauth",
+                "refresh": "r-token",
+                "access": "a-token",
+                "expires": 123,
+            },
+            "corp": {"type": "wellknown", "key": "wk-key", "token": "wk-token"},
+        }
+        (auth_dir / "auth.json").write_text(json.dumps(auth))
+
+        update_cli_tokens("new-token")
+
+        result = json.loads((auth_dir / "auth.json").read_text())
+        assert result["databricks"]["key"] == "new-token"
+        assert result["anthropic"] == auth["anthropic"], "oauth credential mutated"
+        assert result["corp"]["token"] == "wk-token"
+        assert result["corp"]["key"] == "wk-key", "wellknown key mutated"
+
+    def test_ignores_legacy_api_key_shape(self, isolated_home):
+        """A file left over from the old (invalid) writer has no `type`, so it
+        isn't a credential opencode can load. Don't pretend rotating it works."""
+        from cli_auth import update_cli_tokens
+        auth_dir = isolated_home / ".local" / "share" / "opencode"
+        auth_dir.mkdir(parents=True)
+        (auth_dir / "auth.json").write_text(json.dumps({"databricks": {"api_key": "old"}}))
+
+        update_cli_tokens("new-token")
+
+        result = json.loads((auth_dir / "auth.json").read_text())
+        assert result["databricks"] == {"api_key": "old"}
 
     def test_skips_missing_file(self, isolated_home):
         from cli_auth import update_cli_tokens
@@ -267,7 +326,9 @@ class TestAllCLIsUpdated:
 
         oc_dir = isolated_home / ".local" / "share" / "opencode"
         oc_dir.mkdir(parents=True)
-        (oc_dir / "auth.json").write_text(json.dumps({"databricks": {"api_key": "old"}}))
+        (oc_dir / "auth.json").write_text(
+            json.dumps({"databricks": {"type": "api", "key": "old"}})
+        )
 
         gemini_dir = isolated_home / ".gemini"
         gemini_dir.mkdir()
@@ -285,7 +346,7 @@ class TestAllCLIsUpdated:
         assert json.loads((claude_dir / "settings.json").read_text())["env"]["ANTHROPIC_AUTH_TOKEN"] == "rotated-token"
         assert json.loads((pi_dir / "models.json").read_text())["providers"]["databricks-claude"]["apiKey"] == "rotated-token"
         assert "OPENAI_API_KEY=rotated-token" in (codex_dir / ".env").read_text()
-        assert json.loads((oc_dir / "auth.json").read_text())["databricks"]["api_key"] == "rotated-token"
+        assert json.loads((oc_dir / "auth.json").read_text())["databricks"]["key"] == "rotated-token"
         assert "GEMINI_API_KEY=rotated-token" in (gemini_dir / ".env").read_text()
         hermes_content = (hermes_dir / "config.yaml").read_text()
         assert hermes_content.count("api_key: rotated-token") == 2

--- a/tests/test_content_filter_proxy.py
+++ b/tests/test_content_filter_proxy.py
@@ -104,3 +104,203 @@ def test_sse_line_decodes_literal_utf8_without_latin1_mojibake():
 
     raw = 'data: {"text":"✓ café → │ ─ 😀"}'.encode("utf-8")
     assert _decode_sse_line(raw) == 'data: {"text":"✓ café → │ ─ 😀"}'
+
+
+# ---------------------------------------------------------------------------
+# Request sanitisation for providers that reject parts of the OpenAI shape
+# ---------------------------------------------------------------------------
+
+class TestGeminiSchemaStripping:
+    """Gemini's function-declaration schema rejects several JSON Schema
+    keywords. It 400s the whole request rather than ignoring them, so an
+    unstripped key makes the tool unusable, not merely unvalidated."""
+
+    def test_strips_numeric_and_array_validation_keywords(self):
+        import content_filter_proxy as cfp
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "n": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "exclusiveMaximum": 10,
+                    "multipleOf": 2,
+                },
+                "items": {"type": "array", "uniqueItems": True},
+            },
+        }
+
+        cleaned = cfp.strip_unsupported_schema_keys(schema)
+
+        props = cleaned["properties"]
+        for key in ("exclusiveMinimum", "exclusiveMaximum", "multipleOf"):
+            assert key not in props["n"], f"{key} should have been stripped"
+        assert "uniqueItems" not in props["items"]
+        # Non-offending keys survive.
+        assert props["n"]["type"] == "number"
+
+    def test_drops_range_bounds_on_integer_properties(self):
+        """Gemini rejects minimum/maximum specifically on integer types."""
+        import content_filter_proxy as cfp
+
+        cleaned = cfp.strip_unsupported_schema_keys(
+            {"type": "integer", "minimum": 1, "maximum": 5}
+        )
+
+        assert cleaned == {"type": "integer"}
+
+    def test_keeps_range_bounds_on_number_properties(self):
+        """...but not on numbers — over-stripping loses real constraints."""
+        import content_filter_proxy as cfp
+
+        cleaned = cfp.strip_unsupported_schema_keys(
+            {"type": "number", "minimum": 1, "maximum": 5}
+        )
+
+        assert cleaned["minimum"] == 1
+        assert cleaned["maximum"] == 5
+
+    def test_strips_recursively_through_nested_schemas(self):
+        import content_filter_proxy as cfp
+
+        cleaned = cfp.strip_unsupported_schema_keys(
+            {"properties": {"a": {"items": [{"type": "integer", "minimum": 0}]}}}
+        )
+
+        assert cleaned["properties"]["a"]["items"][0] == {"type": "integer"}
+
+
+class TestGptReasoningKeyStripping:
+    """reasoning_effort / reasoningSummary are GPT-family fields. Stripping is
+    scoped by model id: removing them from a model that supports reasoning
+    silently downgrades output quality."""
+
+    def test_strips_for_gpt_models(self):
+        import content_filter_proxy as cfp
+
+        data = cfp.sanitize_tool_schemas({
+            "model": "databricks-gpt-5-5",
+            "reasoning_effort": "high",
+            "reasoningSummary": "auto",
+        })
+
+        assert "reasoning_effort" not in data
+        assert "reasoningSummary" not in data
+
+    def test_preserves_for_non_gpt_models(self):
+        import content_filter_proxy as cfp
+
+        data = cfp.sanitize_tool_schemas({
+            "model": "databricks-claude-opus-4-8",
+            "reasoning_effort": "high",
+        })
+
+        assert data["reasoning_effort"] == "high"
+
+    def test_model_match_is_case_insensitive(self):
+        import content_filter_proxy as cfp
+
+        data = cfp.sanitize_tool_schemas({
+            "model": "Databricks-GPT-5-5", "reasoning_effort": "low",
+        })
+
+        assert "reasoning_effort" not in data
+
+    def test_missing_model_field_does_not_raise(self):
+        import content_filter_proxy as cfp
+
+        data = cfp.sanitize_tool_schemas({"reasoning_effort": "high"})
+
+        assert data["reasoning_effort"] == "high"
+
+
+class TestContentBlockFlattening:
+    """Some served models answer chat-completions with `content` as an array of
+    typed blocks. OpenAI-shaped clients like OpenCode expect a string and render
+    the raw array (or drop the message) otherwise."""
+
+    def test_flattens_text_blocks_to_a_string(self):
+        import content_filter_proxy as cfp
+
+        out = cfp._flatten_content_blocks(
+            [{"type": "text", "text": "Hello "}, {"type": "text", "text": "world"}]
+        )
+
+        assert out == "Hello world"
+
+    def test_ignores_non_text_blocks(self):
+        import content_filter_proxy as cfp
+
+        out = cfp._flatten_content_blocks(
+            [{"type": "thinking", "thinking": "hmm"}, {"type": "text", "text": "answer"}]
+        )
+
+        assert out == "answer"
+
+    def test_passes_through_plain_strings(self):
+        import content_filter_proxy as cfp
+
+        assert cfp._flatten_content_blocks("already a string") == "already a string"
+
+    def test_passes_through_none(self):
+        import content_filter_proxy as cfp
+
+        assert cfp._flatten_content_blocks(None) is None
+
+    def test_applied_to_non_streaming_message(self):
+        import content_filter_proxy as cfp
+
+        fixed = cfp.fix_response_data({
+            "choices": [{"message": {"content": [{"type": "text", "text": "hi"}]}}]
+        })
+
+        assert fixed["choices"][0]["message"]["content"] == "hi"
+
+    def test_applied_to_streaming_delta(self):
+        import content_filter_proxy as cfp
+
+        fixed = cfp.fix_response_data({
+            "choices": [{"delta": {"content": [{"type": "text", "text": "chunk"}]}}]
+        })
+
+        assert fixed["choices"][0]["delta"]["content"] == "chunk"
+
+    def test_does_not_invent_a_content_field(self):
+        """A tool-call-only message has no `content`; adding an empty string
+        could be read as an empty assistant turn."""
+        import content_filter_proxy as cfp
+
+        fixed = cfp.fix_response_data({"choices": [{"message": {"tool_calls": []}}]})
+
+        assert "content" not in fixed["choices"][0]["message"]
+
+
+class TestToollessRequestsAreStillSanitised:
+    """There used to be an early return for requests without `tools`, so the
+    top-level cleanup never ran on plain chat turns."""
+
+    def test_strips_stream_options_without_tools(self):
+        import content_filter_proxy as cfp
+
+        data = cfp.sanitize_tool_schemas({"model": "m", "stream_options": {"x": 1}})
+
+        assert "stream_options" not in data
+
+    def test_strips_top_level_schema_without_tools(self):
+        import content_filter_proxy as cfp
+
+        data = cfp.sanitize_tool_schemas({"model": "m", "$schema": "http://x"})
+
+        assert "$schema" not in data
+
+    def test_tool_schemas_still_sanitised_when_present(self):
+        import content_filter_proxy as cfp
+
+        data = cfp.sanitize_tool_schemas({
+            "model": "m",
+            "tools": [{"function": {"parameters": {"type": "object",
+                                                   "additionalProperties": False}}}],
+        })
+
+        assert "additionalProperties" not in data["tools"][0]["function"]["parameters"]

--- a/tests/test_opencode_auth_schema.py
+++ b/tests/test_opencode_auth_schema.py
@@ -1,0 +1,161 @@
+"""OpenCode's auth.json credential schema, and the writer/rotator contract.
+
+Two places touch `~/.local/share/opencode/auth.json` and must agree:
+
+- `setup_opencode.py` writes it at setup time.
+- `cli_auth._update_opencode()` rewrites the secret on every PAT rotation
+  (~10 min).
+
+Both used to write `api_key`. That is not a field opencode recognises — its
+credentials are a discriminated union on `type`, and the API-key variant keeps
+the secret in `key`:
+
+    export class Api extends Schema.Class<Api>("ApiAuth")({
+        type: Schema.Literal("api"),
+        key: Schema.String,
+        metadata: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+    }) {}
+
+    const _Info = Schema.Union([Oauth, Api, WellKnown])
+        .annotate({ discriminator: "type", identifier: "Auth" })
+
+(opencode, packages/opencode/src/auth/index.ts)
+
+Because both sides were *consistently* wrong, every unit test passed, and the
+content-filter proxy masked the effect at runtime by injecting a fresh bearer
+token per request. The missing assertion was that the writer's output is a shape
+the rotator can rotate — so that's what this file pins down.
+
+The shape now lives in one place (`utils.opencode_api_credential`), which is
+what actually prevents the drift; these tests hold both sides to it.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import pytest
+
+from utils import (
+    OPENCODE_AUTH_KEY_FIELD,
+    is_opencode_api_credential,
+    opencode_api_credential,
+)
+
+# The union discriminants opencode accepts.
+VALID_AUTH_TYPES = {"api", "oauth", "wellknown"}
+
+
+class TestCredentialShape:
+    def test_uses_tagged_union_shape(self):
+        assert opencode_api_credential("tok") == {"type": "api", "key": "tok"}
+
+    def test_does_not_emit_api_key(self):
+        """`api_key` was the original bug. Assert it can never come back."""
+        assert "api_key" not in opencode_api_credential("tok")
+
+    def test_declares_a_valid_discriminant(self):
+        assert opencode_api_credential("tok")["type"] in VALID_AUTH_TYPES
+
+    @pytest.mark.parametrize(
+        "cred,expected",
+        [
+            ({"type": "api", "key": "k"}, True),
+            # The old, unloadable shape — must not be treated as rotatable.
+            ({"api_key": "k"}, False),
+            # Other union members carry different fields; rotating them would
+            # corrupt a credential opencode still needs.
+            ({"type": "oauth", "refresh": "r", "access": "a", "expires": 1}, False),
+            ({"type": "wellknown", "key": "k", "token": "t"}, False),
+            ({"type": "api"}, False),  # missing key
+            ("not-a-dict", False),
+            (None, False),
+        ],
+    )
+    def test_recognises_only_rotatable_api_credentials(self, cred, expected):
+        assert is_opencode_api_credential(cred) is expected
+
+
+class TestWriterAndRotatorAgree:
+    """The regression guard: whatever the writer produces, the rotator must be
+    able to rotate. Either half drifting silently breaks token rotation.
+
+    This exercises the real rotator against the real writer's output, without
+    running setup_opencode.py — that script resolves the gateway and a token over
+    the network, so spawning it makes the test slow and non-hermetic.
+    """
+
+    def _write_auth(self, home, providers):
+        auth_dir = home / ".local" / "share" / "opencode"
+        auth_dir.mkdir(parents=True, exist_ok=True)
+        path = auth_dir / "auth.json"
+        # Exactly what setup_opencode.py writes, via the same helper.
+        path.write_text(
+            json.dumps({p: opencode_api_credential(tok) for p, tok in providers.items()}, indent=2)
+        )
+        path.chmod(0o600)
+        return path
+
+    def test_rotator_updates_what_the_writer_wrote(self, tmp_path):
+        import cli_auth
+
+        path = self._write_auth(
+            tmp_path, {"databricks": "old", "databricks-openai": "old"}
+        )
+
+        with mock.patch.object(cli_auth, "_HOME", str(tmp_path)):
+            cli_auth._update_opencode("rotated-token")
+
+        result = json.loads(path.read_text())
+        for provider in ("databricks", "databricks-openai"):
+            assert result[provider][OPENCODE_AUTH_KEY_FIELD] == "rotated-token", (
+                f"{provider}: rotator did not update the field the writer wrote — "
+                f"setup_opencode.py and cli_auth._update_opencode() have drifted"
+            )
+            # `type` is the union discriminant; losing it makes the credential
+            # unparseable even though the secret is correct.
+            assert result[provider]["type"] == "api"
+
+    def test_rotation_preserves_0600(self, tmp_path):
+        """auth.json holds a live token. The writer chmods it 0600 and rotation
+        must not widen it (os.replace installs the tmp file's mode)."""
+        import stat
+
+        import cli_auth
+
+        path = self._write_auth(tmp_path, {"databricks": "old"})
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+        with mock.patch.object(cli_auth, "_HOME", str(tmp_path)):
+            cli_auth._update_opencode("rotated-token")
+
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    def test_rotation_is_idempotent(self, tmp_path):
+        import cli_auth
+
+        path = self._write_auth(tmp_path, {"databricks": "old"})
+
+        with mock.patch.object(cli_auth, "_HOME", str(tmp_path)):
+            cli_auth._update_opencode("tok")
+            first = path.read_text()
+            cli_auth._update_opencode("tok")
+
+        assert path.read_text() == first
+
+
+class TestSetupOpencodeUsesTheSharedHelper:
+    """Guard against setup_opencode.py hand-rolling the credential dict again."""
+
+    def test_source_imports_and_calls_the_helper(self):
+        from pathlib import Path
+
+        src = (Path(__file__).resolve().parent.parent / "setup_opencode.py").read_text()
+        assert "opencode_api_credential" in src, (
+            "setup_opencode.py should build credentials via "
+            "utils.opencode_api_credential() so the shape stays in one place"
+        )
+        assert '"api_key"' not in src and "'api_key'" not in src, (
+            "setup_opencode.py must not write `api_key` — opencode reads `key`"
+        )

--- a/utils.py
+++ b/utils.py
@@ -505,3 +505,52 @@ def workspace_sync_dest(repo_name: str) -> str:
         or "_local"
     )
     return f"/Workspace/Shared/coda/{app_name}/{repo_name}"
+
+
+# ---------------------------------------------------------------------------
+# OpenCode credential schema
+# ---------------------------------------------------------------------------
+#
+# opencode stores credentials at ~/.local/share/opencode/auth.json as a map of
+# provider-id -> credential, where the credential is a discriminated union on
+# `type`. The API-key variant keeps the secret in `key`:
+#
+#     export class Api extends Schema.Class<Api>("ApiAuth")({
+#         type: Schema.Literal("api"),
+#         key: Schema.String,
+#         metadata: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+#     }) {}
+#
+#     const _Info = Schema.Union([Oauth, Api, WellKnown])
+#         .annotate({ discriminator: "type", identifier: "Auth" })
+#
+# (opencode, packages/opencode/src/auth/index.ts)
+#
+# Two places touch this file and MUST agree, or token rotation silently stops
+# working: setup_opencode.py writes it, and cli_auth._update_opencode() rewrites
+# the secret on every PAT rotation. They previously both used `api_key` — not a
+# field opencode recognises — so the credential was unloadable and each rotation
+# faithfully updated a key nothing read. Defining the shape once here is what
+# stops that drifting again.
+
+OPENCODE_AUTH_TYPE_API = "api"
+OPENCODE_AUTH_KEY_FIELD = "key"
+
+
+def opencode_api_credential(key: str) -> dict:
+    """Build an opencode API-key credential in its tagged-union shape."""
+    return {"type": OPENCODE_AUTH_TYPE_API, OPENCODE_AUTH_KEY_FIELD: key}
+
+
+def is_opencode_api_credential(cred) -> bool:
+    """True if `cred` is an opencode API-key credential this code may rotate.
+
+    Deliberately narrow: `oauth` and `wellknown` credentials carry different
+    fields, and writing a PAT into one would corrupt a credential opencode
+    still needs.
+    """
+    return (
+        isinstance(cred, dict)
+        and cred.get("type") == OPENCODE_AUTH_TYPE_API
+        and OPENCODE_AUTH_KEY_FIELD in cred
+    )


### PR DESCRIPTION
Cherry-picks the still-relevant parts of #79 (@mpkrass7) onto current `main`. Merging that branch wholesale would have reverted a lot — it predates main's SP-OAuth token resolution, proxy tracing, mtime-invalidated token cache, the opus-4-8 catalog with 1M context limits, and the `enterprise_config.npm_env` wiring.

## 1. `auth.json` was the wrong shape (real bug on main)

opencode stores credentials as a **discriminated union on `type`**; the API-key variant keeps the secret in `key`:

```ts
export class Api extends Schema.Class<Api>("ApiAuth")({
    type: Schema.Literal("api"),
    key: Schema.String,
    ...
}) {}

const _Info = Schema.Union([Oauth, Api, WellKnown])
    .annotate({ discriminator: "type", identifier: "Auth" })
```
<sub>opencode, `packages/opencode/src/auth/index.ts`</sub>

`api_key` is **not** a field opencode recognises, and both sides wrote it:

- `setup_opencode.py` → `{"databricks": {"api_key": ...}}`
- `cli_auth._update_opencode()` → rotated `api_key` every ~10 min

So the credential was unloadable, and every rotation updated a key nothing reads.

**Why nobody noticed:** the two were *consistently* wrong — the old tests asserted `api_key` explicitly — and OpenCode routes through the content-filter proxy, which injects a fresh bearer per request and masks the broken credential at runtime.

The shape now lives once in `utils.opencode_api_credential()` / `is_opencode_api_credential()`, shared by writer and rotator. That's what stops the drift recurring, rather than just fixing both call sites — same reasoning as the existing `workspace_sync_dest()` helper. Rotation is now also scoped to `type == "api"`, so `oauth`/`wellknown` credentials can't have a PAT written into them.

## 2. Tool-less requests skipped sanitisation entirely (also pre-existing)

`sanitize_tool_schemas()` early-returned when a request had no `tools`, so the top-level cleanup below it — `stream_options`, `$schema` — **never ran on a plain chat turn**. Found by a test written for the new GPT stripping, which failed until the early return came out.

## 3. Proxy compatibility fixes

- Strip `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `uniqueItems` — Gemini 400s the whole request on these, so an unstripped key makes the tool unusable, not merely unvalidated.
- Drop `minimum`/`maximum` on `type: integer` **only** — kept for `number`, since over-stripping loses real constraints.
- Strip `reasoning_effort`/`reasoningSummary` for **GPT-routed models only**. Stripping globally would silently downgrade output on reasoning-capable models.
- Flatten Anthropic-style `content` arrays to a string in both `message` and streaming `delta`. Absent `content` stays absent rather than becoming `""`, so a tool-call-only message isn't turned into an empty assistant turn.

## Not taken

The `setup_opencode.py` model-catalog rewrite (main's is newer) and the `pydantic-core` pin (main has 2.46.4 after #110).

## Verification

**535 tests pass.** New `tests/test_opencode_auth_schema.py` holds the contract that was missing: whatever the writer emits, the real rotator must be able to rotate, with 0600 preserved. Confirmed the auth and early-return tests fail without their fixes.

⚠️ The Gemini/GPT fixes are **latent** while `app.yaml` disables Codex and Gemini (no compatible gateway endpoints). The auth.json fix is **not** latent — OpenCode is enabled.

Credit to @mpkrass7 for finding the auth.json schema mismatch and the Gemini/GPT request-shaping issues.