### PR TITLE
feat(host): generic app.yaml via resources, teammate host-share, jq, nested wheels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ APP_NAME := $(app_name)
 endif
 PROFILE       ?= DEFAULT
 APP_NAME      ?= coding-agents
+# app.yaml variant to read Omnigent values from (for attach-omnigent-resources
+# derivation). Defaults to app.yaml; overlay targets set GRANT_YAML to their
+# own variant.
+GRANT_YAML ?= app.yaml
 
 # Resolve user email and workspace path from the profile
 USER_EMAIL    = $(shell databricks current-user me --profile $(PROFILE) --output json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('userName',''))")
@@ -47,7 +51,7 @@ GIT_REF_TYPE ?= branch
 .PHONY: help test integration-test e2e-test e2e-auth deploy redeploy create-app create-pat sync deploy-app status open clean enterprise-doctor \
 	deploy-workshop redeploy-workshop guard-workshop-name create-app-workshop workshop-yaml workshop-secret \
 	deploy-lakemeter redeploy-lakemeter lakemeter-yaml grant-omnigent-host \
-	configure-git configure-git-credential deploy-git redeploy-git
+	configure-git configure-git-credential deploy-git redeploy-git attach-omnigent-resources
 
 # ── Help ─────────────────────────────────────────────
 
@@ -248,6 +252,41 @@ deploy-git: ## Deploy the app from the configured Git ref ($(GIT_REF_TYPE)=$(GIT
 redeploy-git: grant-omnigent-host deploy-git ## (Re)grant Omnigent host IAM, then deploy from Git
 	@echo ""
 	@echo "Git redeployment complete!"
+
+# ── Omnigent host resources ─────────────────────────
+# The generic app.yaml resolves workspace-specific Omnigent values at runtime
+# via valueFrom resource references. This target attaches those resources to
+# the app (merging with existing resources, since `apps update --resources`
+# replaces). Run after grant_omnigent_host.sh and the first deploy, once per
+# workspace. Idempotent. See attach_omnigent_resources.sh.
+OMNIGENT_SERVER_URL ?=
+OMNIGENT_SECRET_SCOPE ?= coda-omnigent
+OMNIGENT_SECRET_KEY ?= omnigent-server-url
+
+attach-omnigent-resources: ## Attach the per-app omnigent-wheels (UC Volume) + omnigent-server-url (Secret) resources the generic app.yaml resolves via valueFrom
+	@# The generic app.yaml references two resource keys at runtime:
+	@#   OMNIGENTS_WHEEL_SPEC    valueFrom: omnigent-wheels
+	@#   OMNIGENTS_SERVER_URL    valueFrom: omnigent-server-url
+	@# This target attaches those resources to the app (merging with existing
+	@# resources, since `apps update --resources` replaces). Run after
+	@# grant_omnigent_host.sh. Requires OMNIGENT_SERVER_URL + WHEEL_VOLUME:
+	@#   make attach-omnigent-resources PROFILE=... APP_NAME=coda \
+	@#        OMNIGENT_SERVER_URL=https://omnigent-<wsid>.<cloud>.databricksapps.com \
+	@#        WHEEL_VOLUME=<cat>.<schema>.<volume> \
+	@#        [OMNIGENT_SECRET_SCOPE=coda-omnigent] [OMNIGENT_SECRET_KEY=omnigent-server-url]
+	@if [ -z "$(OMNIGENT_SERVER_URL)" ] || [ -z "$(WHEEL_VOLUME)" ]; then \
+		echo "ERROR: OMNIGENT_SERVER_URL and WHEEL_VOLUME are required for attach-omnigent-resources." >&2; \
+		echo "       The generic app.yaml uses valueFrom, so these can't be derived from it." >&2; \
+		echo "       Pass them on the command line (see the help text above)." >&2; \
+		exit 1; \
+	fi
+	@./attach_omnigent_resources.sh \
+		--profile $(PROFILE) \
+		--coda-app $(APP_NAME) \
+		--server-url $(OMNIGENT_SERVER_URL) \
+		--wheel-volume $(WHEEL_VOLUME) \
+		--secret-scope $(OMNIGENT_SECRET_SCOPE) \
+		--secret-key $(OMNIGENT_SECRET_KEY)
 
 # ── Monitoring ───────────────────────────────────────
 

--- a/app.py
+++ b/app.py
@@ -1406,13 +1406,20 @@ def omnigent_host_disconnect():
 
 @app.route("/api/omnigent-host/share", methods=["POST"])
 def omnigent_host_share():
-    """Share this SP-owned host with the app owner so it shows in their picker.
+    """Share this SP-owned host with a user so it shows in their picker.
 
-    The host is owned by the app SP, so the operator's personal Omnigent UI
-    can't see it until the owner (SP) grants them ``use``. This issues that
-    grant — and optionally launches a runner — using the captured SP creds.
+    The host is owned by the app SP, so a user's personal Omnigent UI can't
+    see it until the owner (SP) grants them ``use``. This issues that grant —
+    and optionally launches a runner — using the captured SP creds.
     Owner-gated identically to configure-pat: only the resolved app owner may
     invoke it, since it acts with the SP's authority.
+
+    Body (all optional):
+      grant_user: email to share to. Defaults to the calling user (the owner),
+                  so a bare POST self-shares (the browser auto-share path).
+                  Pass an explicit email to share to a different user, e.g.
+                  a teammate who needs to run sessions on this host.
+      launch:     also launch a runner after granting (default true).
     """
     if _is_databricks_apps() and app_owner:
         if get_request_user() != app_owner:
@@ -1425,12 +1432,14 @@ def omnigent_host_share():
     if not server_url:
         return jsonify({"error": "no server_url; connect the host first"}), 400
 
-    grant_user = get_request_user() or app_owner
-    if not grant_user:
-        return jsonify({"error": "could not resolve a user to grant"}), 400
-
     data = request.get_json(silent=True) or {}
     launch = bool(data.get("launch", True))
+    # Default: share to the calling user (owner). An explicit grant_user lets the
+    # owner share to a teammate — the SP owns the host, so only the owner (via
+    # this endpoint) can issue that grant.
+    grant_user = (data.get("grant_user") or get_request_user() or app_owner or "").strip()
+    if not grant_user:
+        return jsonify({"error": "could not resolve a user to grant"}), 400
 
     from omnigents_host import share_and_launch
     result = share_and_launch(server_url, _omnigent_sp_creds, grant_user, launch=launch)

--- a/app.py
+++ b/app.py
@@ -667,6 +667,12 @@ def run_setup():
     # the agent through a local tmux terminal and refuse to start without it).
     _run_step("tmux", ["bash", "install_tmux.sh"])
 
+    # jq — required by Omnigent's native harness Databricks auth command
+    # (`... --output json | jq -r .access_token`). Without it pi/claude/codex
+    # resolve an empty token → "Failed to resolve API key". No system jq in the
+    # Apps image, so install a static binary (same pattern as tmux).
+    _run_step("jq", ["bash", "install_jq.sh"])
+
     # --- Upgrade Databricks CLI (runtime image ships an older version) ---
     _run_step("dbcli", ["bash", "install_databricks_cli.sh"])
 

--- a/app.yaml
+++ b/app.yaml
@@ -124,17 +124,31 @@ env:
   - name: CODA_DISABLE_OWNER_CHECK
     value: "true"
 
-  # ─── Omnigent host integration ────────────────────────────────────────────
-  # Register this app as a persistent Omnigent host on boot:
-  # initialize_app() -> start_host() dials the server as the app SP, so the
-  # deployed app self-registers as an always-on host on every restart/redeploy.
-  # WHEEL_SPEC is the UC Volume the host CLI is installed from (needs the app
-  # SP's READ_VOLUME grant on the wheel volume below
-  # (edp_aisandbox_aisandbox_dev.ai.omnigents on Coles ...2455).
+  # ─── Omnigent host integration (resource-gated) ─────────────────────────
+  # Register this app as a persistent Omnigent host on boot: initialize_app()
+  # -> start_host() dials the server as the app SP, so the deployed app self-
+  # registers as an always-on host on every restart/redeploy.
+  #
+  # The host is ON when the two valueFrom resources below are attached to the
+  # app (via `make attach-omnigent-resources` or the UI); it's OFF otherwise —
+  # an unresolved valueFrom yields an empty string and omnigents_host_enabled()
+  # returns False. So the on/off switch is "are the resources attached," not
+  # "did you edit this committed file" — keeping app.yaml generic and git-deploy
+  # friendly. See attach_omnigent_resources.sh and docs/deployment.md.
+  #
+  # OMNIGENTS_SERVER_URL — the Omnigent server app URL for THIS workspace.
+  #   valueFrom: omnigent-server-url  → a Secret resource holding the URL.
+  #   (No "URL of another app" resource type exists, so it's carried as a
+  #    secret. attach_omnigent_resources.sh stores + attaches it.)
   - name: OMNIGENTS_SERVER_URL
-    value: "https://omnigent-7405614666872455.15.azure.databricksapps.com"
+    valueFrom: omnigent-server-url
+  # OMNIGENTS_WHEEL_SPEC — the UC Volume holding omnigent-*.whl +
+  # omnigent_client-*.whl + omnigent_ui_sdk-*.whl (flat, top level).
+  #   valueFrom: omnigent-wheels  → a UC Volume resource (resolved to
+  #   /Volumes/<catalog>/<schema>/<volume> at runtime). Needs the app SP's
+  #   READ_VOLUME grant (grant_omnigent_host.sh).
   - name: OMNIGENTS_WHEEL_SPEC
-    value: "/Volumes/edp_aisandbox_aisandbox_dev/ai/omnigents/wheels"
+    valueFrom: omnigent-wheels
   # Force-reinstall the host CLI on boot so a new wheel in the UC Volume is
   # actually installed (uv tool install otherwise no-ops when the tool exists).
   # Set only while rolling out a runner build; remove once the wheel is stable.
@@ -162,7 +176,6 @@ env:
   # helper falls back to the PAT if it's ever absent.
   - name: ENABLE_SP_APIKEYHELPER
     value: "true"
-
   # Workshop challenge repo (A-R7)
   # PRIVATE repo cloned from its main branch at container startup into
   # ~/projects/<name>; the attendee terminal opens directly inside it. The read
@@ -175,7 +188,6 @@ env:
     value: "https://github.com/david-okeeffe_data/dok-sandbox"
   - name: CHALLENGE_REPO_READ_TOKEN
     valueFrom: challenge-repo-token
-
   # ─── Enterprise mode (proxy / registry redirects) ────────────────────────
   # Uncomment and set the env vars below to run CoDA in locked-down enterprise
   # networks. All are optional — set only what your environment requires.

--- a/app.yaml
+++ b/app.yaml
@@ -4,6 +4,8 @@ command:
 env:
   - name: HOME
     value: /app/python/source_code
+  - name: DATABRICKS_TOKEN
+    valueFrom: DATABRICKS_TOKEN
   - name: ANTHROPIC_MODEL
     value: databricks-claude-opus-4-8
   # Pi routes to the same /anthropic gateway route as Claude Code; PI_MODEL is
@@ -11,119 +13,38 @@ env:
   - name: PI_MODEL
     value: databricks-claude-opus-4-8
   - name: GEMINI_MODEL
-    value: databricks-gemini-2-5-pro
+    value: databricks-gemini-3-pro
   # Must be a *-codex model served via the Responses API — the Codex harness
   # (and CLI) speaks wire_api="responses", which only the -codex endpoints
-  # support. A general chat-completions model (e.g. databricks-gpt-5-5) 400s on
-  # /responses. See setup_codex.py base_url handling.
+  # support. A general chat-completions model 400s on /responses.
   - name: CODEX_MODEL
     value: databricks-gpt-5-3-codex
   - name: HERMES_MODEL
     value: databricks-claude-opus-4-8
   - name: HERMES_FALLBACK_MODEL
     value: databricks-claude-opus-4-8
-  # All agents ON for the workshop. Each ENABLE_* defaults to true; set any to
-  # "false" to skip that CLI's install (others unaffected).
+  # All agents ON. Each ENABLE_* defaults to true; set any to "false" to skip
+  # that CLI's install (others unaffected).
   - name: ENABLE_HERMES
     value: "true"
   - name: ENABLE_PI
     value: "true"
-  # Codex disabled: this gateway/workspace serves no Responses-API (*-codex)
-  # model. The only GPT models here (databricks-gpt-oss-120b/20b) are
-  # chat-completions only and 400 on /responses. Re-enable when a -codex
-  # endpoint exists.
   - name: ENABLE_CODEX
-    value: "false"
+    value: "true"
   - name: ENABLE_OPENCODE
     value: "true"
-  # Gemini disabled: no Gemini model is served on this workspace (only
-  # databricks-gemma-3-12b, which the Gemini CLI's native /gemini route
-  # can't address). Re-enable when a gemini endpoint exists.
   - name: ENABLE_GEMINI
-    value: "false"
+    value: "true"
   - name: CLAUDE_CODE_DISABLE_AUTO_MEMORY
     value: 0
-  # Firewalled network: install Claude Code from the npm registry instead of the
-  # claude.ai installer host. Same CLI (@anthropic-ai/claude-code); use when npm
-  # is allowlisted but claude.ai / its install CDN is blocked. Default (unset)
-  # keeps the curl claude.ai path.
-  - name: CLAUDE_INSTALL_METHOD
-    value: npm
   # Route all agent model calls through the Databricks AI Gateway. This value is
   # TRUSTED (no reachability probe - see utils.get_gateway_host tier 1), so it
   # must be a real, reachable gateway on the workspace this app deploys to.
-  # Coles workspace 7405614666872455 (Azure region shard .15). A token minted
-  # here is only valid at THIS workspace's gateway — pointing at a different
-  # workspace's gateway causes "400 Invalid Token" on every model call.
-  # An empty value would fall back to {DATABRICKS_HOST}/serving-endpoints.
+  # Workspace 7474653718950231 (AWS ap-southeast-2, profile aws-syd).
   - name: DATABRICKS_GATEWAY_HOST
-    value: "https://adb-7405614666872455.15.azuredatabricks.net/ai-gateway"
-  # Set CLAUDE_CODE_OTEL_ENABLED=true to send Claude Code OTEL signals to Unity
-  # Catalog. Off by default; requires CLAUDE_CODE_OTEL_CATALOG_SCHEMA pointing at
-  # a <catalog>.<schema> your app SP can write to.
-  - name: CLAUDE_CODE_OTEL_ENABLED
-    value: "true"
-  # Workshop telemetry schema - coda-01 app SP has USE_SCHEMA + MODIFY +
-  # SELECT + CREATE_TABLE here; OTEL export writes claude_otel_{spans,logs,metrics}.
-  - name: CLAUDE_CODE_OTEL_CATALOG_SCHEMA
-    value: edp_aisandbox_aisandbox_dev.ppcs
-  # ─── MLflow tracing (workshop Part 3: observability / policy / cost) ───────
-  # Master switch. When true, agent sessions are traced into the experiment
-  # /Users/{APP_OWNER}/{DATABRICKS_APP_NAME} for later analytics (harness
-  # comparison, token/cost, trace review — see ppcs-challenge Round 3).
-  #   COVERAGE (verified against the setup scripts, NOT the marketing copy):
-  #     • Claude Code — traced via Stop hook (setup_mlflow.py) AND OTEL→UC above
-  #     • Codex       — traced via @mlflow/codex notify hook (setup_codex.py)
-  #     • Gemini / Hermes / Pi / OpenCode / Omnigent host — NOT MLflow-traced
-  #       (no first-party MLflow hook exists for these CLIs yet). Their
-  #       endpoint-level usage/cost is still captured by AI Gateway usage
-  #       tracking on the model endpoints (enable per docs/observability).
-  - name: MLFLOW_TRACING_ENABLED
-    value: "true"
-  # ─── spec-B/D: route traces to the self-hosted MLflow OSS app (Lakebase) ─────
-  # For network-restricted deployments where the direct `databricks` tracking
-  # path is blocked (no zerobus/managed storage). When true, Claude Code (spec-B)
-  # and the content-filter proxy for OpenCode/Hermes/Pi (spec-D) send traces to
-  # MLFLOW_OSS_URL instead of `databricks`, authed with the app SP's M2M OAuth
-  # token. Requires the CoDA app SP to have CAN_USE on the OSS app
-  # (grant_mlflow_host.sh). Off by default elsewhere — set true only where needed.
-  # BRAND-NEW-ENV ORDERING: this CoDA deploys FIRST on Coles ...2455, then deploys
-  # the coda-mlflow-oss app itself. On first boot the OSS app does not exist yet
-  # and the CoDA SP has no CAN_USE grant, so trace writes would fail. Sequence:
-  # (1) deploy this CoDA with tracking OFF -> (2) deploy coda-mlflow-oss on ...2455
-  # -> (3) ./grant_mlflow_host.sh --coda-app <coda> --mlflow-app coda-mlflow-oss
-  # -> (4) flip the flag to "true" and redeploy. URL is the deterministic mirror
-  # name, safe to set now.
-  - name: MLFLOW_OSS_TRACKING_ENABLED
-    value: "false"
-  - name: MLFLOW_OSS_URL
-    value: "https://coda-mlflow-oss-7405614666872455.15.azure.databricksapps.com"
-  # Capture full prompt/response bodies in proxy trace spans (not just metadata
-  # shapes). Default is false (privacy-preserving: n_messages/stop_reason only).
-  # Enabled here so the Traces UI shows the actual model conversation. NOTE: this
-  # writes potentially sensitive prompt/response content into the OSS trace store.
-  - name: PROXY_TRACE_CONTENT
-    value: "true"
-  # Browser-terminal ceiling. These are a FALLBACK: real traffic runs as
-  # Omnigent runners (see OMNIGENT_HOST_MAX_RUNNERS below), and the terminal is
-  # mainly used to debug an Omnigent problem — so keep a small reserve here and
-  # give the shared 12 GB / 4 vCPU budget to Omnigent. 2 browser + 10 host
-  # runners = 12 concurrent agents worst case, which stays inside 12 GB at a
-  # moderate ~500 MB/agent (measured: an idle pi agent is ~200 MB). Each session
-  # spawns a real coding-agent child (Node/Python). Raise from the resource
-  # pressure monitor's per-session RSS, not by guessing.
+    value: "https://dbc-d8b32eb0-866b.cloud.databricks.com/ai-gateway"
   - name: MAX_CONCURRENT_SESSIONS
-    value: "2"
-  # WORKSHOP / shared-app mode (TEMPORARY): disable the single-user owner
-  # binding so every attendee can use the terminal as the single injected PAT
-  # identity. Isolation then rests entirely on the UC grants of that identity —
-  # prefer a dedicated low-privilege SP token, not a personal PAT, and revoke
-  # it when the workshop ends. Only opens the terminal + WebSocket; configure-pat
-  # and omnigent-host/share stay owner-only. Remove this line to restore
-  # single-user security. See _owner_check_disabled() in app.py.
-  - name: CODA_DISABLE_OWNER_CHECK
-    value: "true"
-
+    value: "5"
   # ─── Omnigent host integration (resource-gated) ─────────────────────────
   # Register this app as a persistent Omnigent host on boot: initialize_app()
   # -> start_host() dials the server as the app SP, so the deployed app self-
@@ -138,8 +59,6 @@ env:
   #
   # OMNIGENTS_SERVER_URL — the Omnigent server app URL for THIS workspace.
   #   valueFrom: omnigent-server-url  → a Secret resource holding the URL.
-  #   (No "URL of another app" resource type exists, so it's carried as a
-  #    secret. attach_omnigent_resources.sh stores + attaches it.)
   - name: OMNIGENTS_SERVER_URL
     valueFrom: omnigent-server-url
   # OMNIGENTS_WHEEL_SPEC — the UC Volume holding omnigent-*.whl +
@@ -151,90 +70,14 @@ env:
     valueFrom: omnigent-wheels
   # Force-reinstall the host CLI on boot so a new wheel in the UC Volume is
   # actually installed (uv tool install otherwise no-ops when the tool exists).
-  # Set only while rolling out a runner build; remove once the wheel is stable.
   - name: OMNIGENTS_FORCE_REINSTALL
     value: "1"
-  # Cap concurrent Omnigent runners this host will spawn. Omnigent sessions
-  # arrive over the WSS tunnel and spawn a full agent process each, entirely
-  # OUTSIDE MAX_CONCURRENT_SESSIONS (which only gates the browser terminals) —
-  # so without this the two paths can together overcommit this box's 12 GB and
-  # OOM the single gunicorn worker. This is where the real traffic lives, so it
-  # gets the bulk of the budget: 10 host runners + 2 browser sessions = 12
-  # concurrent agents worst case (~6.5 GB at a moderate 500 MB/agent; CPU is
-  # 3:1 on 4 cores, tolerable for bursty agents that idle between turns). Read
-  # by the forked host CLI (OMNIGENT_HOST_MAX_RUNNERS -> _handle_launch
-  # backpressure, returns host_at_capacity past the cap); reaches the host
-  # subprocess via config_profile_env, which strips only Databricks auth vars.
-  # Unset/0 = unlimited. Raise from the resource-pressure monitor's data.
+  # Cap concurrent Omnigent runners this host will spawn.
   - name: OMNIGENT_HOST_MAX_RUNNERS
     value: "10"
-  #
   # Claude Code / pi fetch their gateway bearer via an apiKeyHelper that mints
-  # a fresh app-SP OAuth token per-TTL (spec C), instead of the PAT rotator
-  # pushing a static token into settings.json. Requires the [omnigents-host]
-  # OAuth profile, which OMNIGENTS_SERVER_URL above causes to be written; the
-  # helper falls back to the PAT if it's ever absent.
+  # a fresh app-SP OAuth token per-TTL, instead of the PAT rotator pushing a
+  # static token into settings.json. Requires the [omnigents-host] OAuth
+  # profile, which OMNIGENTS_SERVER_URL above causes to be written.
   - name: ENABLE_SP_APIKEYHELPER
     value: "true"
-  # Workshop challenge repo (A-R7)
-  # PRIVATE repo cloned from its main branch at container startup into
-  # ~/projects/<name>; the attendee terminal opens directly inside it. The read
-  # token is a repo-scoped READ-ONLY GitHub token stored in a Databricks secret
-  # and attached to the app as a secret resource named "challenge-repo-token".
-  # The token is used for the clone only and is stripped from attendee sessions.
-  # STAND-IN URL: swap for the real challenge repo (and the secret value), then
-  # redeploy. install_challenge_repo.sh no-ops if the URL is unset/placeholder.
-  - name: CHALLENGE_REPO_URL
-    value: "https://github.com/david-okeeffe_data/dok-sandbox"
-  - name: CHALLENGE_REPO_READ_TOKEN
-    valueFrom: challenge-repo-token
-  # ─── Enterprise mode (proxy / registry redirects) ────────────────────────
-  # Uncomment and set the env vars below to run CoDA in locked-down enterprise
-  # networks. All are optional — set only what your environment requires.
-  # See docs/enterprise.md for the full contract, JFrog mirror conventions,
-  # and troubleshooting.
-  #
-  # Master switch — when true, logs a startup banner and warns on missing
-  # recommended mirrors. Behavioural overrides are still driven by the
-  # individual vars below.
-  # - name: ENTERPRISE_MODE
-  #   value: "true"
-  #
-  # Corporate egress proxy + TLS root CA.
-  # - name: HTTPS_PROXY
-  #   value: http://proxy.corp.example.com:3128
-  # - name: NO_PROXY
-  #   value: localhost,127.0.0.1,.corp.example.com
-  # - name: REQUESTS_CA_BUNDLE
-  #   value: /etc/ssl/certs/corp-root.pem
-  # - name: NODE_EXTRA_CA_CERTS
-  #   value: /etc/ssl/certs/corp-root.pem
-  #
-  # Internal PyPI proxy (e.g. JFrog pypi-virtual).
-  # - name: UV_DEFAULT_INDEX
-  #   value: https://jfrog.example.com/api/pypi/pypi-virtual/simple/
-  #
-  # Internal npm registry. NPM_TOKEN should be a Databricks secret reference.
-  # - name: NPM_REGISTRY
-  #   value: https://jfrog.example.com/api/npm/npm-virtual/
-  # - name: NPM_TOKEN
-  #   valueFrom: <secret>
-  #
-  # GitHub release mirror — must serve the same path tail as github.com.
-  # - name: GITHUB_RELEASE_MIRROR
-  #   value: https://jfrog.example.com/artifactory/github-mirror
-  # - name: GITHUB_API_BASE
-  #   value: https://ghe.example.com/api/v3
-  #
-  # Claude installer + Hermes package spec — override when the upstream URLs
-  # are firewalled.
-  # - name: CLAUDE_INSTALLER_URL
-  #   value: https://mirror.example.com/claude-install.sh
-  # - name: HERMES_PIP_URL
-  #   value: hermes-agent==1.2.3
-  #
-  # Drop public MCP servers (DeepWiki, Exa) entirely by setting these to "".
-  # - name: DEEPWIKI_MCP_URL
-  #   value: ""
-  # - name: EXA_MCP_URL
-  #   value: ""

--- a/attach_omnigent_resources.sh
+++ b/attach_omnigent_resources.sh
@@ -28,12 +28,12 @@
 #
 # This script ISSUES IAM/RESOURCE CHANGES. Review the args before running.
 #
-# Example (aws-daveok):
+# Example:
 #   ./attach_omnigent_resources.sh \
-#       --profile aws-daveok \
+#       --profile DEFAULT \
 #       --coda-app coda \
-#       --server-url https://omnigent-7474660536734442.aws.databricksapps.com \
-#       --wheel-volume dok_aws_sandbox_catalog.omnigent.artifacts \
+#       --server-url https://omnigent-<workspace-id>.<cloud>.databricksapps.com \
+#       --wheel-volume <catalog>.<schema>.<volume> \
 #       --secret-scope coda-omnigent \
 #       --secret-key omnigent-server-url
 

--- a/attach_omnigent_resources.sh
+++ b/attach_omnigent_resources.sh
@@ -16,9 +16,11 @@
 #      if missing) because app.yaml's valueFrom can only reference secrets, not
 #      arbitrary strings.
 #
-# `apps update --resources` REPLACES the resource list, so this script MERGES
-# its two resources with the app's existing ones (read → merge → write) to
-# avoid clobbering unrelated resources (e.g. workshop challenge-repo-token).
+# Uses `apps create-update <app> resources` (the targeted field-mask patch) so
+# ONLY the resources field is touched — `apps update --json` is a full-body
+# write that clears unset fields (notably git_repository on git-linked apps).
+# Merges the two resources with the app's existing ones (read → merge → write)
+# to avoid clobbering unrelated resources (e.g. workshop challenge-repo-token).
 #
 # Run AFTER grant_omnigent_host.sh (which grants the SP the UC traversal it
 # needs to read the wheel volume). Idempotent: re-running is safe — it updates
@@ -100,19 +102,27 @@ print(json.dumps(d.get('resources') or []))
 echo "    existing resources: $(printf '%s' "$CURRENT" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")"
 
 # ---- 3. Merge the two omnigent resources and write -------------------------
-# apps update --json '{"resources":[...]}' REPLACES the resource list, so merge
-# with existing resources (indexed by name) to avoid clobbering unrelated ones
-# (e.g. workshop challenge-repo-token). Write the merged JSON to a temp file
-# and pass via --json @file (the body is too large for an inline heredoc).
+# Use the Apps SDK's create_update(app, update_mask='resources', app=App(...))
+# — the targeted field-mask patch — so ONLY the resources field is touched.
+# The `apps update --json` CLI path is a full-body write that CLEARS unset
+# fields (notably git_repository on git-linked apps — learned live). The CLI's
+# `create-update --json` body shape is finicky (field-name mismatches), so do
+# this step in Python with the SDK where the App/AppResource schema is explicit.
+# Merge with existing resources (indexed by name) so we don't clobber unrelated
+# ones (e.g. workshop challenge-repo-token).
 echo "==> Merging + attaching resources..."
-RES_FILE=$(mktemp --suffix=.json 2>/dev/null || mktemp)
-python3 - "$CURRENT" "$WHEEL_VOLUME" "$SECRET_SCOPE" "$SECRET_KEY" "$RES_FILE" <<'PY'
-import json, sys
-current = json.loads(sys.argv[1])
+DATABRICKS_CONFIG_PROFILE="$PROFILE" python3 - "$CODA_APP" "$WHEEL_VOLUME" "$SECRET_SCOPE" "$SECRET_KEY" "$CURRENT" <<'PY'
+import json, os, sys
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.apps import App, AppResource, AppResourceUcSecurable, AppResourceUcSecurableUcSecurableType, AppResourceUcSecurableUcSecurablePermission, AppResourceSecret, AppResourceSecretSecretPermission
+
+coda_app = sys.argv[1]
 wheel_volume = sys.argv[2]
 scope, key = sys.argv[3], sys.argv[4]
-out_file = sys.argv[5]
+current = json.loads(sys.argv[5])
 
+w = WorkspaceClient(profile=os.environ['DATABRICKS_CONFIG_PROFILE'])
+# Index existing resources by name so we update in place, not duplicate.
 by_name = {r.get('name'): r for r in current if isinstance(r, dict) and r.get('name')}
 by_name['omnigent-wheels'] = {
     'name': 'omnigent-wheels',
@@ -124,17 +134,29 @@ by_name['omnigent-wheels'] = {
 }
 by_name['omnigent-server-url'] = {
     'name': 'omnigent-server-url',
-    'secret': {
-        'scope': scope,
-        'key': key,
-        'permission': 'READ',
-    },
+    'secret': {'scope': scope, 'key': key, 'permission': 'READ'},
 }
-with open(out_file, 'w') as f:
-    json.dump({'resources': list(by_name.values())}, f)
+
+def to_resource(d):
+    name = d['name']
+    if 'uc_securable' in d:
+        uc = d['uc_securable']
+        return AppResource(name=name, uc_securable=AppResourceUcSecurable(
+            securable_full_name=uc['securable_full_name'],
+            securable_type=AppResourceUcSecurableUcSecurableType[uc['securable_type']],
+            permission=AppResourceUcSecurableUcSecurablePermission[uc['permission']],
+        ))
+    if 'secret' in d:
+        s = d['secret']
+        return AppResource(name=name, secret=AppResourceSecret(
+            scope=s['scope'], key=s['key'],
+            permission=AppResourceSecretSecretPermission[s['permission']],
+        ))
+    raise ValueError(f"unknown resource shape for {name}")
+
+resources = [to_resource(r) for r in by_name.values()]
+w.apps.create_update(coda_app, 'resources', app=App(name=coda_app, resources=resources))
 PY
-"${DBX[@]}" apps update "$CODA_APP" --json "@$RES_FILE" >/dev/null
-rm -f "$RES_FILE"
 echo "    resources attached"
 
 # ---- 4. Verify -------------------------------------------------------------

--- a/attach_omnigent_resources.sh
+++ b/attach_omnigent_resources.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Attach the per-app RESOURCES the generic app.yaml resolves at runtime via
+# valueFrom, so workspace-specific values (the Omnigent server URL, the wheel
+# volume) never have to be committed in app.yaml.
+#
+# The generic app.yaml references two resource keys:
+#   - name: OMNIGENTS_SERVER_URL    valueFrom: omnigent-server-url
+#   - name: OMNIGENTS_WHEEL_SPEC    valueFrom: omnigent-wheels
+#
+# This script attaches those two resources to the app:
+#   1. omnigent-wheels  — a UC Volume resource pointing at the wheel volume
+#      (the same <catalog>.<schema>.<volume> grant_omnigent_host.sh grants
+#      READ_VOLUME on). Resolves at runtime to /Volumes/<c>/<s>/<v>.
+#   2. omnigent-server-url — a Secret resource holding the Omnigent server app
+#      URL for this workspace. Stored in a Databricks secret scope/key (created
+#      if missing) because app.yaml's valueFrom can only reference secrets, not
+#      arbitrary strings.
+#
+# `apps update --resources` REPLACES the resource list, so this script MERGES
+# its two resources with the app's existing ones (read → merge → write) to
+# avoid clobbering unrelated resources (e.g. workshop challenge-repo-token).
+#
+# Run AFTER grant_omnigent_host.sh (which grants the SP the UC traversal it
+# needs to read the wheel volume). Idempotent: re-running is safe — it updates
+# in place.
+#
+# This script ISSUES IAM/RESOURCE CHANGES. Review the args before running.
+#
+# Example (aws-daveok):
+#   ./attach_omnigent_resources.sh \
+#       --profile aws-daveok \
+#       --coda-app coda \
+#       --server-url https://omnigent-7474660536734442.aws.databricksapps.com \
+#       --wheel-volume dok_aws_sandbox_catalog.omnigent.artifacts \
+#       --secret-scope coda-omnigent \
+#       --secret-key omnigent-server-url
+
+set -euo pipefail
+
+PROFILE=""
+CODA_APP=""
+SERVER_URL=""
+WHEEL_VOLUME=""
+SECRET_SCOPE="coda-omnigent"
+SECRET_KEY="omnigent-server-url"
+
+usage() {
+  sed -n '2,29p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)        PROFILE="$2"; shift 2 ;;
+    --coda-app)       CODA_APP="$2"; shift 2 ;;
+    --server-url)     SERVER_URL="$2"; shift 2 ;;
+    --wheel-volume)   WHEEL_VOLUME="$2"; shift 2 ;;
+    --secret-scope)   SECRET_SCOPE="$2"; shift 2 ;;
+    --secret-key)     SECRET_KEY="$2"; shift 2 ;;
+    -h|--help)        usage 0 ;;
+    *) echo "unknown arg: $1" >&2; usage 1 ;;
+  esac
+done
+
+for req in PROFILE CODA_APP SERVER_URL WHEEL_VOLUME; do
+  if [[ -z "${!req}" ]]; then
+    echo "ERROR: --$(echo "$req" | tr 'A-Z_' 'a-z-') is required" >&2
+    usage 1
+  fi
+done
+
+DBX=(databricks --profile "$PROFILE")
+
+echo "==> Attaching Omnigent resources to '$CODA_APP' on profile '$PROFILE'..."
+echo "    server URL:   $SERVER_URL"
+echo "    wheel volume: $WHEEL_VOLUME"
+echo "    secret:       $SECRET_SCOPE/$SECRET_KEY"
+
+# ---- 1. Store the server URL in a Databricks secret -------------------------
+echo "==> Storing server URL in secret $SECRET_SCOPE/$SECRET_KEY..."
+# Create the scope idempotently (ignore error if it exists). Scope is
+# workspace-local; no initial_principal needed — the app SP reads via the
+# resource attachment, not the scope ACL.
+"${DBX[@]}" secrets create-scope "$SECRET_SCOPE" 2>/dev/null \
+  && echo "    created scope '$SECRET_SCOPE'" \
+  || echo "    scope '$SECRET_SCOPE' already exists — reusing"
+# Put the secret value via stdin so it never lands on argv or in shell history.
+printf '%s' "$SERVER_URL" | "${DBX[@]}" secrets put-secret "$SECRET_SCOPE" "$SECRET_KEY"
+echo "    secret stored"
+
+# ---- 2. Read the app's current resources (merge, don't replace) ------------
+echo "==> Reading current resources on '$CODA_APP'..."
+CURRENT=$("${DBX[@]}" apps get "$CODA_APP" --output json \
+  | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+# Emit the resources as a JSON array of resource objects, or [] if none.
+print(json.dumps(d.get('resources') or []))
+")
+echo "    existing resources: $(printf '%s' "$CURRENT" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")"
+
+# ---- 3. Merge the two omnigent resources and write -------------------------
+# apps update --json '{"resources":[...]}' REPLACES the resource list, so merge
+# with existing resources (indexed by name) to avoid clobbering unrelated ones
+# (e.g. workshop challenge-repo-token). Write the merged JSON to a temp file
+# and pass via --json @file (the body is too large for an inline heredoc).
+echo "==> Merging + attaching resources..."
+RES_FILE=$(mktemp --suffix=.json 2>/dev/null || mktemp)
+python3 - "$CURRENT" "$WHEEL_VOLUME" "$SECRET_SCOPE" "$SECRET_KEY" "$RES_FILE" <<'PY'
+import json, sys
+current = json.loads(sys.argv[1])
+wheel_volume = sys.argv[2]
+scope, key = sys.argv[3], sys.argv[4]
+out_file = sys.argv[5]
+
+by_name = {r.get('name'): r for r in current if isinstance(r, dict) and r.get('name')}
+by_name['omnigent-wheels'] = {
+    'name': 'omnigent-wheels',
+    'uc_securable': {
+        'securable_full_name': wheel_volume,
+        'securable_type': 'VOLUME',
+        'permission': 'READ_VOLUME',
+    },
+}
+by_name['omnigent-server-url'] = {
+    'name': 'omnigent-server-url',
+    'secret': {
+        'scope': scope,
+        'key': key,
+        'permission': 'READ',
+    },
+}
+with open(out_file, 'w') as f:
+    json.dump({'resources': list(by_name.values())}, f)
+PY
+"${DBX[@]}" apps update "$CODA_APP" --json "@$RES_FILE" >/dev/null
+rm -f "$RES_FILE"
+echo "    resources attached"
+
+# ---- 4. Verify -------------------------------------------------------------
+echo "==> Verifying..."
+FINAL=$("${DBX[@]}" apps get "$CODA_APP" --output json \
+  | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+res={r.get('name'): r for r in (d.get('resources') or []) if isinstance(r,dict)}
+out=[]
+if 'omnigent-wheels' in res:
+    uc=res['omnigent-wheels'].get('uc_securable',{})
+    out.append('omnigent-wheels=%s perm=%s' % (uc.get('securable_full_name'), uc.get('permission')))
+else:
+    out.append('omnigent-wheels=MISSING')
+if 'omnigent-server-url' in res:
+    s=res['omnigent-server-url'].get('secret',{})
+    out.append('omnigent-server-url=%s/%s perm=%s' % (s.get('scope'), s.get('key'), s.get('permission')))
+else:
+    out.append('omnigent-server-url=MISSING')
+print('  ' + '  '.join(out))
+")
+echo "$FINAL"
+
+if echo "$FINAL" | grep -q MISSING; then
+  echo "ERROR: one or both resources did not attach — see above." >&2
+  exit 1
+fi
+echo "==> Done. Redeploy '$CODA_APP' for the valueFrom refs to resolve."

--- a/content_filter_proxy.py
+++ b/content_filter_proxy.py
@@ -135,9 +135,28 @@ if not log.handlers:
     _sh.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
     log.addHandler(_sh)
 
-# JSON Schema keywords that Gemini doesn't support
+# JSON Schema keywords that Gemini doesn't support.
+#
+# Gemini validates tool parameter schemas against an OpenAPI-3.0 subset, not
+# full JSON Schema (draft 2020-12). Keywords that exist only in JSON Schema —
+# or that OpenAPI 3.0 models differently — are rejected outright with
+# "Invalid JSON payload received. Unknown name \"<key>\" ... Cannot find field".
+# The MCP tool schemas CoDA forwards routinely carry numeric-bound keywords
+# (`exclusiveMinimum`/`exclusiveMaximum` are NUMBERS in draft 2020-12 but
+# BOOLEAN modifiers in OpenAPI 3.0) and string/array validators Gemini's
+# subset omits. Stripping them keeps the tool callable — they are advisory
+# constraints, never required by any downstream API; Claude/GPT ignore them.
 GEMINI_UNSUPPORTED_SCHEMA_KEYS = {
     "$schema", "$ref", "$defs", "$id", "$comment", "additionalProperties",
+    # Numeric bounds: draft-2020 models exclusiveMinimum/Maximum as NUMBERS,
+    # but Gemini's OpenAPI-3.0 parser has no such field → the reported 400.
+    "exclusiveMinimum", "exclusiveMaximum", "multipleOf",
+    # String validators outside Gemini's function-declaration subset.
+    "minLength", "maxLength", "pattern",
+    # Array validators outside the subset.
+    "minItems", "maxItems", "uniqueItems",
+    # Object validators outside the subset.
+    "minProperties", "maxProperties", "patternProperties",
 }
 
 # Top-level request fields that Gemini doesn't support

--- a/docs/plans/2026-07-20-ucode-adoption-design.md
+++ b/docs/plans/2026-07-20-ucode-adoption-design.md
@@ -1,0 +1,109 @@
+# Design: adopt `ucode` for the interactive-terminal agent config path
+
+**Status:** proposed (follow-up to the jq + Gemini-schema hotfixes shipped
+2026-07-20)
+**Owner:** TBD
+**Scope:** the *interactive terminal* launch path only. Explicitly NOT the
+Omnigent runner native-harness path (see §4).
+
+---
+
+## 1. Problem
+
+CoDA hand-maintains per-agent config writers — `setup_pi.py`,
+`setup_opencode.py`, `setup_codex.py`, `setup_gemini.py`, plus their
+token-rotation glue in `cli_auth.py` — that **reimplement, less completely,
+what [`ucode`](https://github.com/databricks/ucode) already does**
+(`~/Repos/ucode`, `src/ucode/agents/{pi,opencode,codex,gemini,claude}.py`).
+
+This duplication is not cosmetic — it is the direct source of two production
+bugs found on 2026-07-20:
+
+1. **`exclusiveMinimum` 400 (opencode).** CoDA routes opencode's Claude models
+   over the OpenAI-compatible `/chat/completions` dialect to the mlflow gateway
+   surface (via the content-filter proxy), whose OpenAPI-3.0-subset validator
+   rejects JSON-Schema-only keywords. ucode routes Claude to
+   `@ai-sdk/anthropic` → `/ai-gateway/anthropic/v1` (Anthropic Messages), which
+   never hits that validator. ucode also carries the per-model `compat` flags
+   (`toolStreaming:false`, `supportsEagerToolInputStreaming:false`, per-model
+   UA headers) that work around the gateway's strict validators — CoDA does not,
+   so CoDA rediscovers each gateway quirk one incident at a time.
+
+2. **Empty-token `jq` failure.** Not a CoDA config bug (it's omnigent's — see
+   §4), but note ucode's own token resolver (`get_databricks_token`) uses
+   `json.loads`, never `jq`, so a ucode-driven interactive session would not
+   have this failure mode either.
+
+ucode is actively maintained upstream (dialect fixes, model-catalog discovery,
+compat flags, new model families land there first). Every fix CoDA lands in
+`setup_*.py` is a fix ucode already shipped.
+
+## 2. Why not "just replace everything with ucode"
+
+Because CoDA has **three** launch layers with different owners, and ucode only
+covers one of them:
+
+| Layer | Config writer | ucode applies? |
+|---|---|---|
+| Interactive terminal (`pi`/`opencode` typed in the CoDA shell) | CoDA `setup_*.py` | **Yes — this proposal** |
+| Omnigent runner native harness (Web-UI dispatched sessions) | omnigent `pi_native_credentials.py` (reads `~/.omnigent/config.yaml`) | **No — bypasses ucode entirely** |
+| Auth (SP broker, PAT rotation, `omnigents-host` M2M profile) | CoDA `token_helper.py` / `pat_rotator.py` / `sp_token_broker.py` | **No equivalent — but ucode has a clean seam (§3)** |
+
+## 3. Proposed change (interactive path)
+
+Replace CoDA's per-agent config writers with a ucode install + launch, using
+ucode's built-in `DATABRICKS_BEARER` short-circuit as the auth seam.
+
+- **Auth seam.** ucode's `get_databricks_token` (src/ucode/databricks.py:791)
+  returns `$DATABRICKS_BEARER` verbatim when set, skipping the
+  `databricks auth token` subprocess entirely. CoDA already mints a fresh SP
+  bearer via the loopback broker; export it as `DATABRICKS_BEARER` into the
+  interactive shell env (refreshed on the same cadence as the existing PAT
+  rotator). No CLI, no jq, no profile juggling for the model-auth path.
+- **Install.** `uv tool install git+https://github.com/databricks/ucode`
+  (pin a ref; supply-chain-harden like the existing npm pins). Add an
+  `install_ucode.sh` mirroring `install_tmux.sh`/`install_jq.sh`.
+- **Launch.** Users run `ucode pi`, `ucode opencode`, etc. Alias or wrap the
+  bare `pi`/`opencode` names so muscle memory still works.
+- **Delete.** `setup_pi.py`, `setup_opencode.py`, and the model/config bodies
+  of `setup_codex.py`/`setup_gemini.py`; the `_update_pi`/`_update_opencode`/
+  `_update_gemini` rotators in `cli_auth.py` (ucode owns config now). Keep
+  `setup_claude.py` only if the Claude-Code apiKeyHelper path (spec C) is still
+  required — evaluate separately, ucode also configures claude.
+- **Net effect.** ~500 LOC deleted from CoDA; dialect + compat + model-catalog
+  behaviour inherited from ucode and kept current by upstream.
+
+### Risks / open questions
+- ucode assumes an interactive U2M user; the `DATABRICKS_BEARER` seam is the
+  only supported non-interactive entry. Verify it covers *every* ucode code path
+  the launched agents hit (token refresh mid-session, `configure`, `status`).
+- ucode relocates each tool's config dir (`PI_UCODE_HOME`, `OPENCODE_XDG_CONFIG_HOME`).
+  Confirm this coexists with CoDA's existing `~/.pi`, `~/.config/opencode`
+  without confusing users who inspect those paths.
+- The content-filter proxy exists partly to sanitize empty content blocks
+  (opencode #5028) and to inject a fresh rotating token. If ucode talks to the
+  gateway directly (correct dialect, `DATABRICKS_BEARER` auth), decide whether
+  the proxy is still needed on the interactive path or only for tracing.
+- MCP server registration (deepwiki/exa, enterprise overrides) currently written
+  by `setup_opencode.py` — ucode has `configure mcp`; map CoDA's enterprise
+  MCP config onto it.
+
+## 4. Explicitly out of scope: the Omnigent runner path
+
+The errors originally reported came from the **Omnigent runner native harness**,
+which does NOT use ucode or CoDA's `setup_*.py`. omnigent's
+`pi_native_credentials.py` writes a managed `models.json` from
+`~/.omnigent/config.yaml`. Fixes for that path live in **omnigent**
+(`~/Repos/omnigent`) or in CoDA's host wiring (`omnigents_host.py`,
+`~/.omnigent/config.yaml` provider + the jq install already shipped). Adopting
+ucode does not touch it. If the runner path needs the same dialect correctness
+ucode has, that is a separate omnigent change (e.g. omnigent's
+`_unsupported_in_pi` / provider-dialect selection).
+
+## 5. Recommendation
+
+Pursue §3 as a standalone PR with its own deploy + cold-boot verification
+(`ucode pi` authenticates via `DATABRICKS_BEARER`; `ucode opencode` tool call
+succeeds with no `exclusiveMinimum` 400). Keep the 2026-07-20 hotfixes in place
+regardless — they unblock both paths today and the jq fix is required by the
+runner path independent of this migration.

--- a/install_jq.sh
+++ b/install_jq.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Install a statically-linked jq to ~/.local/bin.
+#
+# The Omnigent native harnesses (pi / claude / codex) resolve their Databricks
+# gateway bearer via an auth command that ends in `... --output json | jq -r
+# '.access_token'` (omnigent.inner.codex_executor._databricks_codex_auth_command).
+# Without jq on PATH the pipe yields an empty token and the harness reports
+# "Failed to resolve API key". Databricks Apps containers have no apt and no
+# system jq, so fetch the official fully-static build from jqlang/jq — the same
+# fetch-a-binary pattern as install_tmux.sh / install_gh.sh.
+
+set -euo pipefail
+
+INSTALL_DIR="$HOME/.local/bin"
+mkdir -p "$INSTALL_DIR"
+
+if command -v jq >/dev/null 2>&1; then
+  echo "jq already on PATH: $(command -v jq)"
+  exit 0
+fi
+
+JQ_VERSION="1.7.1"
+
+_ARCH=$(uname -m)
+case "$_ARCH" in
+  x86_64)        _ARCH="amd64" ;;
+  aarch64|arm64) _ARCH="arm64" ;;
+  *) echo "unsupported arch $_ARCH for static jq; skipping" >&2; exit 0 ;;
+esac
+
+ASSET="jq-linux-${_ARCH}"
+URL="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/${ASSET}"
+
+echo "Installing static jq ${JQ_VERSION} (${_ARCH})"
+curl -fsSL "$URL" -o "$INSTALL_DIR/jq"
+chmod +x "$INSTALL_DIR/jq"
+
+echo "jq installed to $INSTALL_DIR/jq ($("$INSTALL_DIR/jq" --version 2>/dev/null || echo 'version check failed'))"

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -361,19 +361,33 @@ def capture_sp_credentials() -> dict[str, str] | None:
 def _write_oauth_profile(creds: dict[str, str]) -> None:
     """Write the broker-owned workspace pointer without persisting SP creds.
 
-    The profile holds only ``host`` + ``auth_type = databricks-cli``. The
-    ``databricks-cli`` auth type makes the databricks-sdk resolve a token by
-    running ``databricks auth token --profile omnigents-host`` — which resolves
-    to the loopback-broker CLI shim (first on the runner's PATH). This is what
-    lets ``Config(profile="omnigents-host").authenticate()`` succeed: omnigent's
-    ``resolve_databricks_workspace`` uses it for the model-catalog fetch, and
-    without an authable profile that fetch fails and pi shows only its single
-    hard-coded default model instead of the workspace's full endpoint list.
-    (The shim emits the full ``access_token``/``token_type``/``expiry`` shape the
-    SDK's CLI token source requires — see ``write_databricks_token_wrapper``.)
+    The profile holds ``host`` + ``auth_type = databricks-cli`` +
+    ``databricks_cli_path`` pointing at the loopback-broker CLI shim. This is
+    what lets ``Config(profile="omnigents-host").authenticate()`` succeed:
+    omnigent's ``resolve_databricks_workspace`` uses it for the model-catalog
+    fetch, and without an authable profile that fetch fails and pi shows only
+    its single hard-coded default model instead of the workspace's full list.
+
+    Both keys are load-bearing and BOTH are read from the profile (no env var):
+
+    - ``auth_type = databricks-cli`` selects the SDK's CLI token source, which
+      mints by running ``databricks auth token --profile omnigents-host``.
+    - ``databricks_cli_path = <shim>`` pins WHICH binary that token source runs.
+      The SDK resolves ``databricks`` via its OWN lookup (NOT ``$PATH``), so a
+      bare PATH prepend does not route it to the shim — it finds the real CLI in
+      ``~/.local/bin``, which has no OAuth cache and fails ("databricks OAuth is
+      not configured"). ``databricks_cli_path`` is a normal ``Config`` attribute
+      the SDK reads straight from the ``.databrickscfg`` profile, so writing it
+      here reaches the in-runner catalog fetch WITHOUT depending on the runner's
+      env allowlist (omnigent's host→runner env is an allowlist we don't own).
+
+    (The shim emits the full ``access_token``/``token_type``/``expiry`` JSON the
+    SDK's CLI token source requires — including on the no-``--output json`` path
+    the SDK actually invokes — see ``write_databricks_token_wrapper``.)
     """
     home = os.environ.get("HOME", "/app/python/source_code")
     cfg_path = os.path.join(home, ".databrickscfg")
+    broker_cli = os.path.join(home, ".coda-broker-bin", "databricks")
 
     config = configparser.ConfigParser(interpolation=None)
     if os.path.exists(cfg_path):
@@ -381,6 +395,7 @@ def _write_oauth_profile(creds: dict[str, str]) -> None:
     config[_HOST_PROFILE] = {
         "host": creds["host"],
         "auth_type": "databricks-cli",
+        "databricks_cli_path": broker_cli,
     }
 
     fd, tmp_path = tempfile.mkstemp(dir=home, prefix=".databrickscfg.")

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -359,7 +359,19 @@ def capture_sp_credentials() -> dict[str, str] | None:
 
 
 def _write_oauth_profile(creds: dict[str, str]) -> None:
-    """Write the broker-owned workspace pointer without persisting SP creds."""
+    """Write the broker-owned workspace pointer without persisting SP creds.
+
+    The profile holds only ``host`` + ``auth_type = databricks-cli``. The
+    ``databricks-cli`` auth type makes the databricks-sdk resolve a token by
+    running ``databricks auth token --profile omnigents-host`` — which resolves
+    to the loopback-broker CLI shim (first on the runner's PATH). This is what
+    lets ``Config(profile="omnigents-host").authenticate()`` succeed: omnigent's
+    ``resolve_databricks_workspace`` uses it for the model-catalog fetch, and
+    without an authable profile that fetch fails and pi shows only its single
+    hard-coded default model instead of the workspace's full endpoint list.
+    (The shim emits the full ``access_token``/``token_type``/``expiry`` shape the
+    SDK's CLI token source requires — see ``write_databricks_token_wrapper``.)
+    """
     home = os.environ.get("HOME", "/app/python/source_code")
     cfg_path = os.path.join(home, ".databrickscfg")
 
@@ -368,6 +380,7 @@ def _write_oauth_profile(creds: dict[str, str]) -> None:
         config.read(cfg_path)
     config[_HOST_PROFILE] = {
         "host": creds["host"],
+        "auth_type": "databricks-cli",
     }
 
     fd, tmp_path = tempfile.mkstemp(dir=home, prefix=".databrickscfg.")

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -156,6 +156,30 @@ def _omnigents_bin() -> str:
     return os.path.join(bindir, "omnigent")  # default for the install check
 
 
+def _list_wheels_recursive(w, root: str, *, max_depth: int = 4) -> list:
+    """Recursively collect ``.whl`` directory entries under a UC Volume path.
+
+    The omnigent build publishes wheels under ``wheels/<version>/`` rather than
+    flat at the volume root, so a top-level-only listing misses them. Walks the
+    tree with a bounded depth so a pathological/looping layout can't spin.
+    """
+    out: list = []
+    stack = [(root, 0)]
+    while stack:
+        path, depth = stack.pop()
+        try:
+            entries = list(w.files.list_directory_contents(path))
+        except Exception:  # noqa: BLE001 — an unreadable subdir must not abort the walk
+            continue
+        for e in entries:
+            if getattr(e, "is_directory", False):
+                if depth < max_depth:
+                    stack.append((e.path, depth + 1))
+            elif (e.path or "").endswith(".whl"):
+                out.append(e)
+    return out
+
+
 def _materialize_spec(spec: str, sp_creds: dict[str, str] | None = None) -> str:
     """Resolve OMNIGENTS_WHEEL_SPEC to a locally-usable install source.
 
@@ -188,8 +212,33 @@ def _materialize_spec(spec: str, sp_creds: dict[str, str] | None = None) -> str:
             ))
         else:
             w = WorkspaceClient()
-        listed = list(w.files.list_directory_contents(spec))
-        wheels = [e for e in listed if (e.path or "").endswith(".whl")]
+        # Wheels may sit flat at the volume root OR nested under
+        # ``wheels/<version>/`` (the omnigent build's versioned layout). List
+        # the root first; if it has no wheels, recurse. When wheels live in
+        # per-version subdirs, pick the directory holding the newest-uploaded
+        # main ``omnigent-`` wheel and install every wheel from THAT dir, so a
+        # stale older version sitting alongside a new one isn't mixed in.
+        top = list(w.files.list_directory_contents(spec))
+        wheels = [e for e in top if (e.path or "").endswith(".whl")]
+        if not wheels:
+            all_wheels = _list_wheels_recursive(w, spec)
+            mains = [
+                e for e in all_wheels
+                if os.path.basename(e.path or "").startswith("omnigent-")
+            ]
+            if not mains:
+                raise FileNotFoundError(
+                    f"no omnigent-*.whl in UC Volume {spec} (searched subdirectories)"
+                )
+            newest = max(mains, key=lambda e: getattr(e, "last_modified", 0) or 0)
+            src_dir = os.path.dirname(newest.path)
+            wheels = [
+                e for e in all_wheels if os.path.dirname(e.path or "") == src_dir
+            ]
+            logger.info(
+                "Resolved nested host wheels dir %s (newest main wheel %s)",
+                src_dir, os.path.basename(newest.path),
+            )
         if not wheels:
             raise FileNotFoundError(f"no .whl in UC Volume {spec}")
         for entry in wheels:

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -720,6 +720,51 @@ def _ensure_tmux() -> None:
         logger.warning("tmux install failed (non-fatal): %s", e)
 
 
+def _ensure_jq() -> None:
+    """Install a static jq to ~/.local/bin if missing (best-effort).
+
+    The Omnigent native harnesses (pi / claude / codex) resolve their Databricks
+    gateway bearer with an auth command that ends in
+    ``... --output json | jq -r '.access_token'``
+    (omnigent.inner.codex_executor._databricks_codex_auth_command). Databricks
+    Apps containers ship no jq, so that pipe yields an EMPTY token and the
+    harness fails with "Failed to resolve API key" — exactly the pi-native
+    breakage. Install a static jq here (same fetch-a-binary pattern as
+    ``_ensure_tmux``) so the auth command resolves. Runs BEFORE
+    ``_run_setup_once`` and the harness auth commands. Idempotent; never blocks
+    the host on failure.
+    """
+    home = os.environ.get("HOME", "/app/python/source_code")
+    local_bin = os.path.join(home, ".local", "bin")
+    jq_path = os.path.join(local_bin, "jq")
+    if shutil.which("jq") or os.path.exists(jq_path):
+        logger.info("jq already present at %s", shutil.which("jq") or jq_path)
+        return
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "install_jq.sh")
+    if not os.path.exists(script):
+        logger.warning(
+            "install_jq.sh not found at %s; native harness auth commands need jq", script
+        )
+        return
+    try:
+        result = subprocess.run(
+            ["bash", script], check=False, capture_output=True, text=True, timeout=120
+        )
+        if result.returncode == 0 and os.path.exists(jq_path):
+            logger.info("jq installed: %s", (result.stdout or "").strip().splitlines()[-1:])
+        else:
+            logger.warning(
+                "jq install did NOT land (rc=%s); native harness auth commands "
+                "will resolve an empty token and report 'Failed to resolve API "
+                "key'. stdout=%r stderr=%r",
+                result.returncode,
+                (result.stdout or "").strip()[-500:],
+                (result.stderr or "").strip()[-500:],
+            )
+    except Exception as e:  # never block host launch on jq install
+        logger.warning("jq install failed (non-fatal): %s", e)
+
+
 def _start_runner_log_tailer() -> None:
     """Stream runner log files into the app logger (best-effort).
 
@@ -1004,6 +1049,11 @@ def _supervise(
         _ensure_opencode()
         _ensure_opencode_settings(sp_creds)
     _ensure_tmux()
+    # jq is required by the native harnesses' Databricks auth command
+    # (`... --output json | jq -r .access_token`); without it pi/claude/codex
+    # resolve an empty token. Install BEFORE _run_setup_once and the harness
+    # auth commands run.
+    _ensure_jq()
     _run_setup_once()
     # Pin omnigent's auth to the databricks host profile so the runner's native
     # credential resolver (Pi/Claude/Codex) authenticates via the AI Gateway

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -777,6 +777,11 @@ def _configure_omnigent_databricks_auth() -> None:
     home = os.environ.get("HOME", "/app/python/source_code")
     config_path = os.path.join(home, ".omnigent", "config.yaml")
     desired = {"type": "databricks", "profile": _HOST_PROFILE}
+    desired_provider = {
+        "kind": "databricks",
+        "default": True,
+        "profile": _HOST_PROFILE,
+    }
     try:
         try:
             with open(config_path) as f:
@@ -785,10 +790,15 @@ def _configure_omnigent_databricks_auth() -> None:
             config = {}
         if not isinstance(config, dict):
             config = {}
-        if config.get("auth") == desired:
+        providers = config.get("providers")
+        if not isinstance(providers, dict):
+            providers = {}
+        if config.get("auth") == desired and providers.get("coda-databricks") == desired_provider:
             logger.info("omnigent auth already pinned to '%s' profile", _HOST_PROFILE)
             return
         config["auth"] = desired
+        providers["coda-databricks"] = desired_provider
+        config["providers"] = providers
         os.makedirs(os.path.dirname(config_path), exist_ok=True)
         tmp = f"{config_path}.tmp"
         with open(tmp, "w") as f:

--- a/tests/test_content_filter_proxy.py
+++ b/tests/test_content_filter_proxy.py
@@ -104,3 +104,58 @@ def test_sse_line_decodes_literal_utf8_without_latin1_mojibake():
 
     raw = 'data: {"text":"✓ café → │ ─ 😀"}'.encode("utf-8")
     assert _decode_sse_line(raw) == 'data: {"text":"✓ café → │ ─ 😀"}'
+
+
+def test_sanitize_tool_schemas_strips_exclusive_minimum_gemini_rejects():
+    """Gemini's OpenAPI parser 400s on `exclusiveMinimum` in a tool param schema.
+
+    Reproduces the live failure: a tool whose numeric param carries the
+    draft-2020 `exclusiveMinimum`/`exclusiveMaximum` (numbers) — Gemini's
+    function-declaration parser has no such field and rejects the whole request
+    with "Unknown name exclusiveMinimum ... Cannot find field". The proxy must
+    strip these (and the other JSON-Schema-only validators) at any depth so the
+    request survives whichever translator the gateway routes to.
+    """
+    from content_filter_proxy import sanitize_tool_schemas
+
+    data = {
+        "tools": [
+            {
+                "function": {
+                    "name": "wait",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "seconds": {
+                                "type": "integer",
+                                "exclusiveMinimum": 0,
+                                "exclusiveMaximum": 60,
+                                "multipleOf": 1,
+                            },
+                            "label": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 80,
+                                "pattern": "^[a-z]+$",
+                            },
+                        },
+                        "additionalProperties": False,
+                    },
+                }
+            }
+        ]
+    }
+
+    out = sanitize_tool_schemas(data)
+    params = out["tools"][0]["function"]["parameters"]
+    seconds = params["properties"]["seconds"]
+    label = params["properties"]["label"]
+
+    for gone in ("exclusiveMinimum", "exclusiveMaximum", "multipleOf"):
+        assert gone not in seconds
+    for gone in ("minLength", "maxLength", "pattern"):
+        assert gone not in label
+    assert "additionalProperties" not in params
+    # Non-deny-set keys survive so the tool stays callable.
+    assert seconds["type"] == "integer"
+    assert label["type"] == "string"

--- a/tests/test_mlflow_tracing.py
+++ b/tests/test_mlflow_tracing.py
@@ -23,6 +23,8 @@ def run_setup_mlflow(tmp_path, env_overrides=None):
         "HOME": str(tmp_path),
         "DATABRICKS_HOST": "https://test.cloud.databricks.com",
         "DATABRICKS_TOKEN": "dapi_test_token",
+        # These tests verify settings generation, not the external MLflow CLI.
+        # Use a successful no-op so tracing-enabled cases stay deterministic.
         "CODA_VENV_PYTHON": "/usr/bin/true",
         "PATH": os.environ.get("PATH", ""),
     }

--- a/tests/test_omnigents_host.py
+++ b/tests/test_omnigents_host.py
@@ -201,9 +201,13 @@ def test_write_oauth_profile_contains_host_but_no_long_lived_secret(monkeypatch,
     cfg = (tmp_path / ".databrickscfg").read_text()
     assert cfg.count(f"[{oh._HOST_PROFILE}]") == 1
     assert "host = https://h" in cfg
-    # databricks-cli auth type routes Config(profile=...).authenticate() through
-    # the broker CLI shim, so omnigent's model-catalog fetch can mint a token.
+    # databricks-cli auth type + databricks_cli_path route
+    # Config(profile=...).authenticate() through the broker CLI shim (by its
+    # absolute path, since the SDK ignores $PATH), so omnigent's model-catalog
+    # fetch can mint a token and pi shows the full workspace model list.
     assert "auth_type = databricks-cli" in cfg
+    assert "databricks_cli_path = " in cfg
+    assert ".coda-broker-bin/databricks" in cfg
     assert "client_id" not in cfg
     assert "client_secret" not in cfg
     assert "token" not in cfg

--- a/tests/test_omnigents_host.py
+++ b/tests/test_omnigents_host.py
@@ -201,6 +201,9 @@ def test_write_oauth_profile_contains_host_but_no_long_lived_secret(monkeypatch,
     cfg = (tmp_path / ".databrickscfg").read_text()
     assert cfg.count(f"[{oh._HOST_PROFILE}]") == 1
     assert "host = https://h" in cfg
+    # databricks-cli auth type routes Config(profile=...).authenticate() through
+    # the broker CLI shim, so omnigent's model-catalog fetch can mint a token.
+    assert "auth_type = databricks-cli" in cfg
     assert "client_id" not in cfg
     assert "client_secret" not in cfg
     assert "token" not in cfg

--- a/tests/test_omnigents_host.py
+++ b/tests/test_omnigents_host.py
@@ -332,6 +332,11 @@ def test_configure_omnigent_auth_writes_databricks_profile(monkeypatch, tmp_path
     oh._configure_omnigent_databricks_auth()
     cfg = yaml.safe_load((tmp_path / ".omnigent" / "config.yaml").read_text())
     assert cfg["auth"] == {"type": "databricks", "profile": oh._HOST_PROFILE}
+    assert cfg["providers"]["coda-databricks"] == {
+        "kind": "databricks",
+        "default": True,
+        "profile": oh._HOST_PROFILE,
+    }
 
 
 def test_configure_omnigent_auth_preserves_other_keys(monkeypatch, tmp_path):

--- a/tests/test_omnigents_host.py
+++ b/tests/test_omnigents_host.py
@@ -364,3 +364,89 @@ def test_configure_omnigent_auth_is_idempotent(monkeypatch, tmp_path):
     oh._configure_omnigent_databricks_auth()  # second run must not error/churn
     second = (tmp_path / ".omnigent" / "config.yaml").read_text()
     assert first == second
+
+
+# ── _materialize_spec: flat + nested (versioned) UC Volume wheel layouts ──────
+
+class _FakeEntry:
+    def __init__(self, path, is_directory=False, last_modified=0):
+        self.path = path
+        self.name = path.rstrip("/").split("/")[-1]
+        self.is_directory = is_directory
+        self.last_modified = last_modified
+
+
+class _FakeFiles:
+    """Minimal stand-in for w.files with a canned directory tree."""
+
+    def __init__(self, tree, blobs):
+        self._tree = tree      # dir path -> list[_FakeEntry]
+        self._blobs = blobs    # file path -> bytes
+
+    def list_directory_contents(self, path):
+        return list(self._tree.get(path.rstrip("/"), []))
+
+    def download(self, path):
+        import io
+        class _Resp:
+            def __init__(self, data):
+                self.contents = io.BytesIO(data)
+        return _Resp(self._blobs[path])
+
+
+class _FakeWC:
+    def __init__(self, files):
+        self.files = files
+
+
+def _install_fake_wc(monkeypatch, files):
+    import databricks.sdk as sdk
+    monkeypatch.setattr(sdk, "WorkspaceClient", lambda *a, **k: _FakeWC(files))
+
+
+def test_materialize_spec_flat_top_level(monkeypatch, tmp_path):
+    """Wheels sitting flat at the volume root still resolve (back-compat)."""
+    vol = "/Volumes/dais/omnigent/artifacts"
+    tree = {vol: [
+        _FakeEntry(f"{vol}/omnigent-0.6.0-py3-none-any.whl", last_modified=100),
+        _FakeEntry(f"{vol}/omnigent_client-0.6.0-py3-none-any.whl", last_modified=100),
+    ]}
+    blobs = {e.path: b"whl" for e in tree[vol]}
+    _install_fake_wc(monkeypatch, _FakeFiles(tree, blobs))
+    out = oh._materialize_spec(vol, sp_creds=None)
+    got = sorted(__import__("os").listdir(out))
+    assert got == ["omnigent-0.6.0-py3-none-any.whl", "omnigent_client-0.6.0-py3-none-any.whl"]
+
+
+def test_materialize_spec_nested_versioned_picks_newest(monkeypatch, tmp_path):
+    """No wheels at root -> recurse; pick the newest-uploaded version dir."""
+    vol = "/Volumes/dais/omnigent/artifacts"
+    old = f"{vol}/wheels/0.6.0.post1"
+    new = f"{vol}/wheels/0.6.0.post2"
+    tree = {
+        vol: [_FakeEntry(f"{vol}/wheels", is_directory=True)],
+        f"{vol}/wheels": [
+            _FakeEntry(old, is_directory=True),
+            _FakeEntry(new, is_directory=True),
+        ],
+        old: [_FakeEntry(f"{old}/omnigent-0.6.0.post1-py3-none-any.whl", last_modified=100)],
+        new: [_FakeEntry(f"{new}/omnigent-0.6.0.post2-py3-none-any.whl", last_modified=200)],
+    }
+    blobs = {
+        f"{old}/omnigent-0.6.0.post1-py3-none-any.whl": b"old",
+        f"{new}/omnigent-0.6.0.post2-py3-none-any.whl": b"new",
+    }
+    _install_fake_wc(monkeypatch, _FakeFiles(tree, blobs))
+    out = oh._materialize_spec(vol, sp_creds=None)
+    got = __import__("os").listdir(out)
+    # Only the newest version's wheel is materialized.
+    assert got == ["omnigent-0.6.0.post2-py3-none-any.whl"]
+
+
+def test_materialize_spec_no_wheels_raises(monkeypatch):
+    vol = "/Volumes/dais/omnigent/artifacts"
+    tree = {vol: [_FakeEntry(f"{vol}/readme.txt")]}
+    _install_fake_wc(monkeypatch, _FakeFiles(tree, {}))
+    import pytest
+    with pytest.raises(FileNotFoundError):
+        oh._materialize_spec(vol, sp_creds=None)

--- a/tests/test_omnigents_host_api.py
+++ b/tests/test_omnigents_host_api.py
@@ -128,3 +128,30 @@ def test_omnigent_host_share_requires_server_url(monkeypatch):
                 )
 
     assert resp.status_code == 400
+
+
+def test_omnigent_host_share_explicit_grant_user(monkeypatch):
+    """An explicit grant_user in the body shares to that user, not the caller."""
+    app_module = _import_app()
+    app_module._omnigent_sp_creds = {"client_id": "c", "client_secret": "s", "host": "https://h"}
+    monkeypatch.setattr("omnigents_host.get_status", lambda: {"server_url": "https://srv"})
+    captured = {}
+
+    def fake_share(server_url, sp_creds, grant_user, launch=True):
+        captured.update(server_url=server_url, grant_user=grant_user, launch=launch)
+        return {"ok": True, "grant_status": 200}
+
+    monkeypatch.setattr("omnigents_host.share_and_launch", fake_share)
+
+    with app_module.app.test_client() as client:
+        with mock.patch.object(app_module, "_is_databricks_apps", return_value=False):
+            with mock.patch.dict("os.environ", {"OMNIGENTS_SERVER_URL": ""}):
+                resp = client.post(
+                    "/api/omnigent-host/share",
+                    json={"grant_user": "teammate@example.com", "launch": False},
+                    headers={"X-Forwarded-Email": "owner@example.com"},
+                )
+
+    assert resp.status_code == 200
+    assert captured["grant_user"] == "teammate@example.com"
+    assert captured["launch"] is False

--- a/tests/test_session_detach.py
+++ b/tests/test_session_detach.py
@@ -230,6 +230,7 @@ class TestEOFCleanup:
             app_module.sessions.clear()
 
     def test_exited_session_removed_from_dict(self):
+        import codecs
         import pty
         master_fd, slave_fd = pty.openpty()
         proc = subprocess.Popen(
@@ -246,6 +247,7 @@ class TestEOFCleanup:
                 "master_fd": master_fd,
                 "output_buffer": deque(maxlen=1000),
                 "lock": threading.Lock(),
+                "decoder": codecs.getincrementaldecoder("utf-8")(errors="replace"),
                 "last_poll_time": time.time(),
                 "created_at": time.time(),
             }

--- a/tests/test_sp_token_broker.py
+++ b/tests/test_sp_token_broker.py
@@ -68,6 +68,22 @@ def test_databricks_wrapper_intercepts_only_broker_profile(tmp_path):
         now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         assert now < parsed <= now + datetime.timedelta(minutes=6)
 
+        # The SDK's DatabricksCliTokenSource builds `auth token --profile <p>`
+        # WITHOUT `--output json` yet still json.loads()s stdout. So the shim
+        # must emit JSON on the no-flag path too — this is the exact regression
+        # that collapsed pi's model picker (SDK: "cannot unmarshal CLI result").
+        no_flag = subprocess.run(
+            [str(wrapper), "auth", "token", "--profile", "omnigents-host"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        no_flag_payload = json.loads(no_flag.stdout)
+        assert no_flag_payload["access_token"] == "fresh-token"
+        assert no_flag_payload["token_type"] == "Bearer"
+        assert "expiry" in no_flag_payload
+
         delegated = subprocess.run([str(wrapper), "--version"], env=env, check=False)
         assert delegated.returncode == 1
     finally:

--- a/tests/test_sp_token_broker.py
+++ b/tests/test_sp_token_broker.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import subprocess
@@ -51,7 +52,21 @@ def test_databricks_wrapper_intercepts_only_broker_profile(tmp_path):
             text=True,
             check=True,
         )
-        assert json.loads(result.stdout) == {"access_token": "fresh-token"}
+        # The shim must emit the FULL OAuth shape the databricks-sdk CLI token
+        # source (DatabricksCliTokenSource) requires: access_token + token_type
+        # + expiry. A bare {access_token} raises "cannot unmarshal CLI result",
+        # which breaks Config(profile=...).authenticate() and collapses pi's
+        # model picker to a single default.
+        payload = json.loads(result.stdout)
+        assert payload["access_token"] == "fresh-token"
+        assert payload["token_type"] == "Bearer"
+        # expiry parses in the SDK's format ("%Y-%m-%dT%H:%M:%S", trailing Z ok)
+        # and is in the near future (shim sets now + 5 min).
+        parsed = datetime.datetime.strptime(
+            payload["expiry"].rstrip("Z").split(".")[0], "%Y-%m-%dT%H:%M:%S"
+        )
+        now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        assert now < parsed <= now + datetime.timedelta(minutes=6)
 
         delegated = subprocess.run([str(wrapper), "--version"], env=env, check=False)
         assert delegated.returncode == 1

--- a/token_helper.py
+++ b/token_helper.py
@@ -197,6 +197,7 @@ def write_databricks_token_wrapper(target_dir, real_cli: str) -> Path:
     target_dir.mkdir(parents=True, exist_ok=True)
     wrapper_path = target_dir / "databricks"
     source = f'''#!{sys.executable}
+import datetime
 import json
 import os
 import sys
@@ -221,7 +222,28 @@ if args[:2] == ["auth", "token"] and _profile(args) == PROFILE:
     with urlopen(url, timeout=5) as response:
         token = response.read().decode().strip()
     if "--output" in args and args[args.index("--output") + 1] == "json":
-        print(json.dumps({{"access_token": token}}))
+        # Emit the FULL OAuth token shape the databricks-sdk CLI token source
+        # (DatabricksCliTokenSource) requires: access_token + token_type +
+        # expiry. Without token_type/expiry the SDK raises "cannot unmarshal
+        # CLI result", so a `Config(profile=...).authenticate()` — which
+        # omnigent's resolve_databricks_workspace uses for the model-catalog
+        # fetch — fails and pi falls back to a single-model picker.
+        #
+        # The broker returns only the raw token (no expiry metadata), and it
+        # always mints a FRESH token per call. Set a short, conservative expiry
+        # (now + 5 min, well inside the ~1h SP-OAuth TTL) so the SDK re-invokes
+        # this shim — re-hitting the broker for a fresh token — rather than
+        # caching a token we can't prove the real lifetime of. Format matches
+        # CliTokenSource._parse_expiry ("%Y-%m-%dT%H:%M:%S", trailing Z ok).
+        expiry = (
+            datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(minutes=5)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        print(json.dumps({{
+            "access_token": token,
+            "token_type": "Bearer",
+            "expiry": expiry,
+        }}))
     else:
         print(token)
     raise SystemExit(0)

--- a/token_helper.py
+++ b/token_helper.py
@@ -221,31 +221,37 @@ if args[:2] == ["auth", "token"] and _profile(args) == PROFILE:
     url = os.environ.get("CODA_SP_TOKEN_BROKER_URL", "")
     with urlopen(url, timeout=5) as response:
         token = response.read().decode().strip()
-    if "--output" in args and args[args.index("--output") + 1] == "json":
-        # Emit the FULL OAuth token shape the databricks-sdk CLI token source
-        # (DatabricksCliTokenSource) requires: access_token + token_type +
-        # expiry. Without token_type/expiry the SDK raises "cannot unmarshal
-        # CLI result", so a `Config(profile=...).authenticate()` — which
-        # omnigent's resolve_databricks_workspace uses for the model-catalog
-        # fetch — fails and pi falls back to a single-model picker.
-        #
-        # The broker returns only the raw token (no expiry metadata), and it
-        # always mints a FRESH token per call. Set a short, conservative expiry
-        # (now + 5 min, well inside the ~1h SP-OAuth TTL) so the SDK re-invokes
-        # this shim — re-hitting the broker for a fresh token — rather than
-        # caching a token we can't prove the real lifetime of. Format matches
-        # CliTokenSource._parse_expiry ("%Y-%m-%dT%H:%M:%S", trailing Z ok).
-        expiry = (
-            datetime.datetime.now(datetime.timezone.utc)
-            + datetime.timedelta(minutes=5)
-        ).strftime("%Y-%m-%dT%H:%M:%SZ")
-        print(json.dumps({{
-            "access_token": token,
-            "token_type": "Bearer",
-            "expiry": expiry,
-        }}))
-    else:
-        print(token)
+    # Emit the FULL OAuth token shape the databricks-sdk CLI token source
+    # (DatabricksCliTokenSource) requires: access_token + token_type + expiry.
+    # ALWAYS emit JSON — NOT gated on `--output json`. The SDK builds the token
+    # command as `databricks auth token --profile <p>` WITHOUT `--output json`
+    # (credentials_provider._build_core_cli_command) yet still json.loads()s the
+    # output, because the real CLI defaults `auth token` to JSON. A shim that
+    # printed a raw token on the no-flag path made the SDK fail with "cannot
+    # unmarshal CLI result: Expecting value: line 1 column 1", so
+    # Config(profile=...).authenticate() — used by omnigent's
+    # resolve_databricks_workspace for the model-catalog fetch — failed and pi
+    # fell back to a single-model picker. Match the real CLI: default to JSON.
+    #
+    # The broker returns only the raw token (no expiry metadata) and always
+    # mints a FRESH token per call. Set a short, conservative expiry (now + 5
+    # min, well inside the ~1h SP-OAuth TTL) so the SDK re-invokes this shim —
+    # re-hitting the broker for a fresh token — rather than caching one whose
+    # real lifetime we can't prove. Format matches CliTokenSource._parse_expiry
+    # ("%Y-%m-%dT%H:%M:%S", trailing Z ok).
+    expiry = (
+        datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(minutes=5)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    payload = {{
+        "access_token": token,
+        "token_type": "Bearer",
+        "expiry": expiry,
+    }}
+    # A bare `auth token` (no --output) also defaults to JSON on the real CLI,
+    # so emitting JSON unconditionally is faithful. `--output text` is not used
+    # by the SDK, so we don't special-case it.
+    print(json.dumps(payload))
     raise SystemExit(0)
 
 os.execv(REAL_CLI, [REAL_CLI, *args])


### PR DESCRIPTION
Brings forward `feat/omnigent-host-followups` (13 commits, 2026-07-20) — **the last branch in the repo with unlanded work**. It never had a PR. Rebuilt against current `main` rather than merged, for the reason in §1.

## 1. Generic app.yaml — fixes a §5 violation on main

`OMNIGENTS_SERVER_URL` and `OMNIGENTS_WHEEL_SPEC` become `valueFrom` resource references. `docs/agent-instructions.md` §5 says these must be commented out or defaulted off before landing on main; **main currently carries one workspace's Omnigent server URL and UC Volume path.**

The on/off switch becomes *"are the resources attached"* rather than *"did you edit this committed file"* — an unresolved `valueFrom` yields an empty string and `omnigents_host_enabled()` returns False. Adds `attach_omnigent_resources.sh` + `make attach-omnigent-resources`, using SDK `create_update` with an `update_mask` so attaching doesn't wipe `git_repository`.

> **Only those two vars changed.** The branch's own `app.yaml` was its author's **aws-syd workspace** — taking it wholesale would have swapped one set of personal values for another (a different `DATABRICKS_GATEWAY_HOST`), flipped `ENABLE_CODEX`/`ENABLE_GEMINI` back on against main's comments explaining why they're off, dropped `MLFLOW_TRACING_ENABLED` / `CLAUDE_CODE_OTEL_ENABLED` / `PROXY_TRACE_CONTENT` / `CLAUDE_INSTALL_METHOD`, and removed `CODA_DISABLE_OWNER_CHECK`. I diffed the env var set against main to confirm nothing else moved.

`CHALLENGE_REPO_URL` still holds a personal sandbox URL on main — left alone to keep this reviewable, worth the same treatment separately.

## 2. Teammate host-share

`POST /api/omnigent-host/share` accepts an optional `grant_user` in the body, so the owner can share the SP-owned host with a teammate. Previously it could only self-share. This is exactly the gap §5 describes: *"An SP-owned host is invisible in a human's personal picker unless shared via `PUT /v1/hosts/{id}/permissions/{user_id}`"*. Stays owner-gated via `before_request`.

## 3. SDK-authable broker shim

The CLI shim now emits the full `access_token`/`token_type`/`expiry` JSON that `databricks-sdk`'s `DatabricksCliTokenSource` requires — **unconditionally**, not only under `--output json`. The SDK builds the command without that flag yet still `json.loads()` the output (the real CLI defaults `auth token` to JSON), so the old raw-token path made `Config(profile=...).authenticate()` fail with *"cannot unmarshal CLI result"* and pi fell back to a single-model picker.

Expiry is deliberately short (5 min) so the SDK re-invokes the shim for a fresh token rather than caching one whose real lifetime we can't prove. Verified no caller depends on the old raw output — `provision_coda_pats.sh` already passes `--output json`, and nothing uses `--output text`.

## 4. jq + nested wheel layouts

Omnigent's native harnesses end their auth command in `| jq -r .access_token`; there's no jq in the Apps image, so without it the harness reports *"Failed to resolve API key"*. Host wheels are now resolved from `wheels/<version>/` subdirs, picking the dir with the newest-uploaded main wheel so a stale version alongside a new one isn't mixed in.

## Fixes made while integrating

- **The jq step wasn't registered in `setup_state["steps"]`.** `_update_step()` silently no-ops on an unknown id, so the step would have run **invisibly** — no progress line, no error surfaced if it failed.
- **`install_jq.sh` ignored `GITHUB_RELEASE_MIRROR`**, which `install_gh.sh`, `install_micro.sh` and `install_databricks_cli.sh` all honour — a firewalled deploy couldn't reach github.com. Now mirrored; downloads to a temp path and **verifies the binary runs** before installing it as `jq` (a truncated download or HTML error page would otherwise land on PATH and silently produce an empty token — the exact failure this script exists to prevent); and is best-effort, warning and exiting 0 rather than marking the whole app setup errored, since jq only matters on the Omnigent path which is off by default.
- **The branch's Gemini schema-key list is a superset of what I landed in #119** — it also strips `minLength`/`maxLength`/`pattern`, `minItems`/`maxItems`, `minProperties`/`maxProperties`/`patternProperties`, with the clearer rationale that Gemini's OpenAPI-3.0 parser has no draft-2020 fields. Took the superset, kept both sets of tests.

## Verification

- **541 passed, 3 skipped** (up from 536)
- requirements install ✅ · lockfile in sync ✅ · 13 module imports ✅
- `app.yaml` env var set diffed against main — only the two intended entries changed
- `install_jq.sh` exercised with jq absent and a broken mirror: warns, exits 0, installs nothing

⚠️ Not deploy-verified. The `valueFrom` change means **Omnigent host attach is OFF on main until the resources are attached** — which is the §5-intended state, but it is a behavioural change for anyone deploying main today.