### PR TITLE
feat(auth): single-user deploys with the PAT as the model-auth identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Beyond boot registration, the host can be driven at runtime:
 
 ### Related
 
-`ENABLE_SP_APIKEYHELPER=true` enables the same loopback-broker boundary for agent gateway calls: helpers fetch short-lived app-SP OAuth tokens without persisting the SP client secret or a static token in terminal-visible configuration.
+`ENABLE_SP_APIKEYHELPER=true` enables the same loopback-broker boundary for agent gateway calls: helpers fetch short-lived app-SP OAuth tokens without persisting the SP client secret or a static token in terminal-visible configuration. It is **off by default**, because it also makes the service principal the identity behind every model call. The default (`CODA_MODEL_AUTH=pat`) signs model calls with the user's PAT instead, so inference is attributed to a real user rather than collapsing onto one principal — see [docs/auth-and-identity.md](docs/auth-and-identity.md).
 
 ---
 
@@ -414,7 +414,9 @@ Open [http://localhost:8000](http://localhost:8000) — type `claude`, `codex`, 
 | `OMNIGENTS_SERVER_URL` | No | Omnigent server to register against on boot. Unset = host integration off (default). See [Omnigent Host Integration](#omnigent-host-integration) |
 | `OMNIGENTS_WHEEL_SPEC` | No | UC Volume path holding the `omnigents host` wheels (app SP needs `READ_VOLUME`). Required when `OMNIGENTS_SERVER_URL` is set |
 | `OMNIGENTS_FORCE_REINSTALL` | No | Set `"1"` to reinstall the host CLI on boot (for rolling out a new wheel); otherwise `uv tool install` no-ops on an existing binary |
-| `ENABLE_SP_APIKEYHELPER` | No | Set `"true"` to broker short-lived app-SP OAuth tokens over loopback without persisting the client secret in terminal-visible configuration |
+| `ENABLE_SP_APIKEYHELPER` | No | Set `"true"` to broker short-lived app-SP OAuth tokens over loopback without persisting the client secret in terminal-visible configuration. Off by default — it makes the **service principal** the model-auth identity, which is the opposite of `CODA_MODEL_AUTH=pat` |
+| `CODA_MODEL_AUTH` | No | Which identity signs agent model calls: `pat` (default) attributes inference to the real user, so AI Gateway usage tracking, cost attribution and per-user governance work; `sp` uses the app service principal for zero-PAT onboarding. The other is always the fallback. See [docs/auth-and-identity.md](docs/auth-and-identity.md) |
+| `CODA_DISABLE_OWNER_CHECK` | No | Set `"true"` for a shared, trusted, time-boxed deployment: any authenticated workspace user may drive the terminal as the single injected identity. Off by default. Note it only opens the terminal + WebSocket — `configure-pat` and `omnigent-host/share` stay owner-only — and it means agent actions are attributed to the injected identity rather than to the person typing |
 | `DEEPWIKI_MCP_URL` | No | Override or disable the DeepWiki MCP server (set to `""` to remove) |
 | `EXA_MCP_URL` | No | Override or disable the Exa MCP server (set to `""` to remove) |
 | `TEAM_MEMORY_MCP_URL` | No | Optional shared-org-memory MCP server URL |

--- a/app.py
+++ b/app.py
@@ -215,6 +215,64 @@ _omnigent_sp_creds = None
 _sp_token_broker_server = None
 
 
+def _require_owner(*, allow_unresolved_during_bootstrap: bool = False):
+    """Gate an owner-only write endpoint. Returns a Flask response to abort with,
+    or None to proceed.
+
+    Fails CLOSED on an unresolved owner by default, matching
+    check_authorization(). Both call sites previously used
+    ``if _is_databricks_apps() and app_owner:``, which short-circuits to *allow*
+    when app_owner is None — so a transient Apps-API failure at boot left them
+    ungated indefinitely.
+
+    ``allow_unresolved_during_bootstrap`` exists for exactly one case:
+    configure-pat. Owner resolution can itself depend on a PAT
+    (get_token_owner() tier 2 calls current_user.me()), so if the Apps API is
+    unavailable AND no PAT is set, requiring a resolved owner here would
+    deadlock — the owner could never finish bootstrap. That window is bounded to
+    "no live PAT configured yet": once one is set the endpoint is owner-gated
+    like everything else, and the single-shot guard further down refuses
+    re-submission anyway. Set APP_OWNER_EMAIL to remove the window entirely.
+
+    Deliberately does NOT consult _owner_check_disabled(): the shared-app opt-out
+    only opens the terminal + WebSocket. These endpoints act with the app SP's
+    authority (or rewrite the shared credential), so they stay owner-only even in
+    shared mode — which is what app.yaml's comment has always promised.
+    """
+    if not _is_databricks_apps():
+        return None  # local dev
+
+    if not app_owner:
+        bootstrapping = not pat_rotator.token
+        if allow_unresolved_during_bootstrap and bootstrapping:
+            logger.warning(
+                "SECURITY: allowing unauthenticated %s — app_owner unresolved and "
+                "no PAT configured yet, so this is the bootstrap window. Whoever "
+                "reaches the app first can claim it. Set APP_OWNER_EMAIL to close "
+                "this window.",
+                request.path,
+            )
+            return None
+        logger.error(
+            "SECURITY: refusing owner-only request to %s — app_owner unresolved "
+            "(fail-closed). Set APP_OWNER_EMAIL to resolve it without an API call.",
+            request.path,
+        )
+        return jsonify({
+            "error": "Forbidden",
+            "message": "App owner could not be resolved; owner-only endpoints are "
+                       "disabled. Set APP_OWNER_EMAIL or restart the app.",
+        }), 403
+
+    if get_request_user() != app_owner:
+        logger.warning(
+            "Rejected owner-only request to %s from non-owner %s (owner: %s)",
+            request.path, get_request_user(), app_owner,
+        )
+        return jsonify({"error": "Forbidden"}), 403
+    return None
+
+
 def _owner_check_disabled() -> bool:
     """True when the operator has opted OUT of the single-user owner binding.
 
@@ -1710,9 +1768,9 @@ def omnigent_host_share():
                   a teammate who needs to run sessions on this host.
       launch:     also launch a runner after granting (default true).
     """
-    if _is_databricks_apps() and app_owner:
-        if get_request_user() != app_owner:
-            return jsonify({"error": "Forbidden"}), 403
+    denied = _require_owner()
+    if denied:
+        return denied
 
     from omnigents_host import get_status
     server_url = os.environ.get("OMNIGENTS_SERVER_URL", "").strip() or str(
@@ -1878,17 +1936,18 @@ def inject_pat():
 @app.route("/api/configure-pat", methods=["POST"])
 def configure_pat():
     """Accept a user-provided PAT, validate it, and start rotation."""
-    # Hotfix: only the resolved owner may (re-)configure the PAT. Without this,
-    # any workspace-SSO'd user who reaches the app can submit their own valid
-    # PAT and persistently impersonate the owner — every CLI call would then
-    # run under the submitter's identity. app_owner is set in initialize_app()
-    # before gunicorn binds, so it's reliably populated by request time on
-    # Databricks Apps; this guard short-circuits to "allow" only when owner
-    # resolution failed (matches the rest of the auth surface's behaviour).
-    if _is_databricks_apps() and app_owner:
-        if get_request_user() != app_owner:
-            logger.warning(f"Rejected configure-pat from non-owner {get_request_user()} (owner: {app_owner})")
-            return jsonify({"error": "Forbidden"}), 403
+    # Only the resolved owner may (re-)configure the PAT. Without this, any
+    # workspace-SSO'd user who reaches the app can submit their own valid PAT and
+    # persistently impersonate the owner — every CLI call would then run under
+    # the submitter's identity. This endpoint is exempt from the before_request
+    # gate, so it is the only thing standing here.
+    #
+    # The bootstrap allowance is narrow and deliberate: an unresolved owner is
+    # tolerated ONLY while no PAT is configured, because owner resolution can
+    # itself require a PAT and would otherwise deadlock. See _require_owner.
+    denied = _require_owner(allow_unresolved_during_bootstrap=True)
+    if denied:
+        return denied
 
     # Idempotency / defence-in-depth: bootstrap is single-shot. Once a PAT
     # is configured and the rotator is alive, refuse re-submission. Without

--- a/app.yaml
+++ b/app.yaml
@@ -125,15 +125,16 @@ env:
   # pressure monitor's per-session RSS, not by guessing.
   - name: MAX_CONCURRENT_SESSIONS
     value: "2"
-  # WORKSHOP / shared-app mode (TEMPORARY): disable the single-user owner
-  # binding so every attendee can use the terminal as the single injected PAT
-  # identity. Isolation then rests entirely on the UC grants of that identity —
-  # prefer a dedicated low-privilege SP token, not a personal PAT, and revoke
-  # it when the workshop ends. Only opens the terminal + WebSocket; configure-pat
-  # and omnigent-host/share stay owner-only. Remove this line to restore
-  # single-user security. See _owner_check_disabled() in app.py.
-  - name: CODA_DISABLE_OWNER_CHECK
-    value: "true"
+  # SHARED-APP mode — deliberately OFF. Uncommenting disables the single-user
+  # owner binding so any authenticated workspace user can drive the terminal as
+  # the one injected PAT identity. Isolation then rests entirely on that
+  # identity's UC grants, and every agent action is attributed to it rather than
+  # to the person typing — which defeats the point of running agents under a
+  # real user identity. Only for a trusted, time-boxed workshop, and prefer a
+  # dedicated low-privilege SP token over a personal PAT.
+  # See _owner_check_disabled() in app.py.
+  # - name: CODA_DISABLE_OWNER_CHECK
+  #   value: "true"
 
   # ─── Omnigent host integration ────────────────────────────────────────────
   # Register this app as a persistent Omnigent host on boot:
@@ -180,13 +181,31 @@ env:
   - name: OMNIGENT_HOST_MAX_RUNNERS
     value: "10"
   #
-  # Claude Code / pi fetch their gateway bearer via an apiKeyHelper that mints
-  # a fresh app-SP OAuth token per-TTL (spec C), instead of the PAT rotator
-  # pushing a static token into settings.json. Requires the [omnigents-host]
-  # OAuth profile, which OMNIGENTS_SERVER_URL above causes to be written; the
-  # helper falls back to the PAT if it's ever absent.
-  - name: ENABLE_SP_APIKEYHELPER
-    value: "true"
+  # App-SP brokered model auth — deliberately OFF. When true, Claude Code / pi
+  # fetch their gateway bearer from an apiKeyHelper that mints a fresh app-SP
+  # OAuth token per-TTL, so **model inference is attributed to the service
+  # principal rather than to the user**. That buys zero-PAT onboarding (agents
+  # install with no paste) at the cost of collapsing all AI Gateway usage, cost
+  # attribution and per-user governance onto one SP identity.
+  #
+  # This deployment prefers the user's PAT for model auth as well as for shell
+  # commands, so agents act as a real user end to end — see CODA_MODEL_AUTH
+  # below. Note the app SP is still used for the Omnigent host tunnel, which
+  # cannot use a PAT (the Apps proxy rejects them).
+  # - name: ENABLE_SP_APIKEYHELPER
+  #   value: "true"
+
+  # Which identity signs agent model calls.
+  #   pat (default) — the user's PAT. Model usage is attributed to the real
+  #                   user, so AI Gateway usage tracking, cost attribution and
+  #                   per-user governance all work. Requires a PAT to have been
+  #                   provided (interactively, or via /api/inject-pat).
+  #   sp            — the app service principal via the loopback token broker.
+  #                   Zero-PAT onboarding, single attributed identity.
+  # Either way the other is used as a fallback when the preferred one is absent,
+  # so a misconfiguration degrades rather than breaks. See token_helper.py.
+  - name: CODA_MODEL_AUTH
+    value: "pat"
 
   # Workshop challenge repo (A-R7) — OPT-IN, both vars unset by default.
   # PRIVATE repo cloned from its main branch at container startup into

--- a/content_filter_proxy.py
+++ b/content_filter_proxy.py
@@ -26,7 +26,11 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from socketserver import ThreadingMixIn
 
 import requests
-from token_helper import resolve_databricks_token, resolve_sp_oauth_token
+from token_helper import (
+    prefer_pat_for_model_auth,
+    resolve_databricks_token,
+    resolve_sp_oauth_token,
+)
 
 UPSTREAM_BASE = os.environ.get("PROXY_UPSTREAM_BASE", "")
 LISTEN_HOST = os.environ.get("PROXY_HOST", "127.0.0.1")
@@ -98,31 +102,37 @@ def _get_fresh_token() -> str | None:
     if cache_hot:
         return _TOKEN_CACHE["token"]
 
-    token = resolve_sp_oauth_token()
-    if token:
+    def _cache(token):
         _TOKEN_CACHE["token"] = token
         _TOKEN_CACHE["read_at"] = now
         _TOKEN_CACHE["mtime"] = mtime
         return token
 
-    try:
-        config = configparser.ConfigParser()
-        config.read(_DATABRICKSCFG_PATH)
-        token = config.get("DEFAULT", "token", fallback=None)
-        if token:
-            _TOKEN_CACHE["token"] = token
-            _TOKEN_CACHE["read_at"] = now
-            _TOKEN_CACHE["mtime"] = mtime
-            return token
-    except Exception as e:
-        log.warning(f"Could not read fresh token from {_DATABRICKSCFG_PATH}: {e}")
+    def _pat_from_cfg():
+        try:
+            config = configparser.ConfigParser()
+            config.read(_DATABRICKSCFG_PATH)
+            return config.get("DEFAULT", "token", fallback=None) or None
+        except Exception as e:
+            log.warning(f"Could not read fresh token from {_DATABRICKSCFG_PATH}: {e}")
+            return None
 
+    # Preferred identity first (CODA_MODEL_AUTH; PAT by default) so proxied
+    # agents sign model calls as the same identity as the browser-terminal ones.
+    # If these disagreed, OpenCode/Hermes/Codex would be attributed to the app SP
+    # while Claude/pi were attributed to the user.
+    if prefer_pat_for_model_auth():
+        token = _pat_from_cfg() or resolve_sp_oauth_token()
+    else:
+        token = resolve_sp_oauth_token() or _pat_from_cfg()
+    if token:
+        return _cache(token)
+
+    # Last resort: the shared resolver (also honours CODA_MODEL_AUTH) picks up
+    # $DATABRICKS_TOKEN, which the cfg read above doesn't see.
     token = resolve_databricks_token()
     if token:
-        _TOKEN_CACHE["token"] = token
-        _TOKEN_CACHE["read_at"] = now
-        _TOKEN_CACHE["mtime"] = mtime
-        return token
+        return _cache(token)
 
     return _TOKEN_CACHE.get("token")  # stale is better than nothing
 

--- a/docs/auth-and-identity.md
+++ b/docs/auth-and-identity.md
@@ -10,8 +10,33 @@ A CoDA container carries **two separate Databricks identities**:
 
 | Identity | What it is | What it's used for |
 |---|---|---|
-| **The user** (e.g. `user@example.com`) via the PAT in `~/.databrickscfg [DEFAULT]` | A **user** personal access token (`dapi…`), kept fresh by the PAT rotator | **Everything the terminal / CLI does**: `databricks` commands, `git`, `gh`, workspace/UC ops, and file writes. |
-| **The app service principal** (e.g. `app-4n8qml coda-02`, an OAuth client_id) | The Databricks App's own SP, no PAT | **Agent model inference**, Omnigent host registration, and spawned-runner callbacks via short-lived OAuth tokens from the loopback broker. |
+| **The user** (e.g. `user@example.com`) via the PAT in `~/.databrickscfg [DEFAULT]` | A **user** personal access token (`dapi…`), kept fresh by the PAT rotator | **Everything the terminal / CLI does**: `databricks` commands, `git`, `gh`, workspace/UC ops, and file writes — **and, by default, agent model inference** (see below). |
+| **The app service principal** (e.g. `app-4n8qml coda-02`, an OAuth client_id) | The Databricks App's own SP, no PAT | Omnigent host registration and spawned-runner callbacks via short-lived OAuth tokens from the loopback broker. The Apps proxy rejects PATs for the host tunnel, so this cannot be a PAT. Also the *fallback* for model inference when no PAT is present. |
+
+### Which identity signs model calls: `CODA_MODEL_AUTH`
+
+Model inference used to be signed with the **app SP**, which collapsed all AI
+Gateway usage, cost attribution and per-user governance onto a single identity —
+every agent on every box looked like the same principal.
+
+The default is now `CODA_MODEL_AUTH=pat`: model calls are signed with the user's
+PAT, so inference is attributed to the real user and matches the identity the
+shell/CLI already uses. Set `CODA_MODEL_AUTH=sp` to go back to the service
+principal, which buys zero-PAT onboarding (agents install with no paste) at the
+cost of that attribution.
+
+Whichever is preferred, the other is the fallback, so a missing PAT degrades
+rather than breaks. Three paths honour the flag and are kept in agreement by
+`tests/test_model_auth_priority.py`: `token_helper.resolve_databricks_token()`,
+the emitted per-request helper script (Claude Code's `apiKeyHelper` and pi's
+`!command`), and `content_filter_proxy._get_fresh_token()` (OpenCode / Hermes /
+Codex). If they disagreed, agents on the same box would run as different
+identities depending on which one you launched.
+
+> **Caveat for shared deployments.** With `CODA_DISABLE_OWNER_CHECK=true` every
+> user drives the terminal as the one injected PAT identity, so "a real user
+> identity" means *the host owner's*, not each person's. Per-user attribution
+> only holds for single-user deploys — which is why that flag is off by default.
 
 ### So: when Claude runs a command on this box, who is it?
 

--- a/tests/test_apikey_helper.py
+++ b/tests/test_apikey_helper.py
@@ -114,14 +114,36 @@ class TestMainOutput:
         out = capsys.readouterr().out
         assert out == "tok-abc"  # exact — no newline, no "Bearer "
 
-    def test_sp_wins_over_pat(self, monkeypatch, capsys):
+    def test_pat_wins_by_default(self, monkeypatch, capsys):
+        """Default is CODA_MODEL_AUTH=pat: model calls are signed with the user's
+        PAT so inference is attributed to a real user, matching the identity the
+        shell/CLI already uses. This inverted a previous SP-first default."""
+        monkeypatch.delenv("CODA_MODEL_AUTH", raising=False)
+        mod = _load_helper_module()
+        monkeypatch.setattr(mod, "_sp_oauth_token", lambda: "sp-loses")
+        monkeypatch.setattr(mod, "_pat_token", lambda: "pat-wins")
+        mod.main()
+        assert capsys.readouterr().out == "pat-wins"
+
+    def test_sp_wins_when_explicitly_selected(self, monkeypatch, capsys):
+        monkeypatch.setenv("CODA_MODEL_AUTH", "sp")
         mod = _load_helper_module()
         monkeypatch.setattr(mod, "_sp_oauth_token", lambda: "sp-wins")
         monkeypatch.setattr(mod, "_pat_token", lambda: "pat-loses")
         mod.main()
         assert capsys.readouterr().out == "sp-wins"
 
-    def test_falls_back_to_pat(self, monkeypatch, capsys):
+    def test_falls_back_to_sp_when_no_pat(self, monkeypatch, capsys):
+        """A missing PAT degrades to the SP rather than failing outright."""
+        monkeypatch.delenv("CODA_MODEL_AUTH", raising=False)
+        mod = _load_helper_module()
+        monkeypatch.setattr(mod, "_pat_token", lambda: None)
+        monkeypatch.setattr(mod, "_sp_oauth_token", lambda: "sp-used")
+        mod.main()
+        assert capsys.readouterr().out == "sp-used"
+
+    def test_falls_back_to_pat_when_sp_selected_but_absent(self, monkeypatch, capsys):
+        monkeypatch.setenv("CODA_MODEL_AUTH", "sp")
         mod = _load_helper_module()
         monkeypatch.setattr(mod, "_sp_oauth_token", lambda: None)
         monkeypatch.setattr(mod, "_pat_token", lambda: "pat-used")

--- a/tests/test_model_auth_priority.py
+++ b/tests/test_model_auth_priority.py
@@ -1,0 +1,184 @@
+"""Which identity signs agent model calls — and that every path agrees.
+
+CoDA has always used the user's PAT for what agents *do* (git, databricks CLI,
+file writes). Model inference, though, was signed with the app service
+principal, so all AI Gateway usage, cost attribution and per-user governance
+collapsed onto one SP identity.
+
+`CODA_MODEL_AUTH` now selects the identity, defaulting to `pat` so agents act as
+a real user end to end. The other identity remains the fallback, so a missing PAT
+(or a missing broker) degrades instead of breaking.
+
+The thing worth testing is not the switch itself but that **three independent
+code paths agree on it**:
+
+  1. `token_helper.resolve_databricks_token()` — the in-process resolver.
+  2. The emitted helper script — runs as a standalone subprocess per request for
+     Claude Code (`apiKeyHelper`) and pi (`!command`), so it cannot import the
+     parent module and duplicates the check.
+  3. `content_filter_proxy._get_fresh_token()` — signs OpenCode / Hermes / Codex.
+
+If these disagreed, browser-terminal agents and proxied agents would run as
+different identities — the exact drift that produced the OpenCode `auth.json`
+bug, where a writer and a rotator quietly diverged on a field name.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import token_helper
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("CODA_MODEL_AUTH", raising=False)
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+
+
+class TestPreferenceFlag:
+    def test_defaults_to_pat(self):
+        assert token_helper.prefer_pat_for_model_auth() is True
+
+    @pytest.mark.parametrize("value", ["sp", "SP", " sp ", "Sp"])
+    def test_sp_selects_service_principal(self, value, monkeypatch):
+        monkeypatch.setenv("CODA_MODEL_AUTH", value)
+        assert token_helper.prefer_pat_for_model_auth() is False
+
+    @pytest.mark.parametrize("value", ["pat", "", "PAT", "anything-else"])
+    def test_everything_else_means_pat(self, value, monkeypatch):
+        """Fail towards the user identity: an unrecognised value must not
+        silently hand model calls to the service principal."""
+        monkeypatch.setenv("CODA_MODEL_AUTH", value)
+        assert token_helper.prefer_pat_for_model_auth() is True
+
+
+class TestInProcessResolver:
+    def test_pat_preferred_by_default(self):
+        with mock.patch.object(token_helper, "resolve_pat", return_value="pat-tok"), \
+             mock.patch.object(token_helper, "resolve_sp_oauth_token", return_value="sp-tok"):
+            assert token_helper.resolve_databricks_token() == "pat-tok"
+
+    def test_sp_preferred_when_selected(self, monkeypatch):
+        monkeypatch.setenv("CODA_MODEL_AUTH", "sp")
+        with mock.patch.object(token_helper, "resolve_pat", return_value="pat-tok"), \
+             mock.patch.object(token_helper, "resolve_sp_oauth_token", return_value="sp-tok"):
+            assert token_helper.resolve_databricks_token() == "sp-tok"
+
+    def test_falls_back_when_preferred_absent(self):
+        with mock.patch.object(token_helper, "resolve_pat", return_value=None), \
+             mock.patch.object(token_helper, "resolve_sp_oauth_token", return_value="sp-tok"):
+            assert token_helper.resolve_databricks_token() == "sp-tok"
+
+    def test_none_when_neither_available(self):
+        with mock.patch.object(token_helper, "resolve_pat", return_value=None), \
+             mock.patch.object(token_helper, "resolve_sp_oauth_token", return_value=None):
+            assert token_helper.resolve_databricks_token() is None
+
+
+class TestEmittedHelperScriptAgrees:
+    """The helper script duplicates the check because it runs standalone. These
+    tests are what stop the duplicate drifting from the original."""
+
+    def test_script_reads_the_same_env_var(self):
+        assert token_helper.MODEL_AUTH_ENV == "CODA_MODEL_AUTH"
+        assert 'os.environ.get("CODA_MODEL_AUTH", "pat")' in token_helper._HELPER_SRC, (
+            "the emitted helper must read CODA_MODEL_AUTH with the same 'pat' "
+            "default as prefer_pat_for_model_auth()"
+        )
+
+    def test_script_compares_against_sp_the_same_way(self):
+        """Both sides must treat only the literal 'sp' as selecting the SP."""
+        assert '.strip().lower() != "sp"' in token_helper._HELPER_SRC
+
+    def test_script_prefers_pat_first_in_main(self):
+        """Order matters: the fallback chain must put the PAT first by default."""
+        main_src = token_helper._HELPER_SRC.split("def main()", 1)[1]
+        assert re.search(r"_pat_token\(\)\s*or\s*_sp_oauth_token\(\)", main_src), (
+            "default branch should be `_pat_token() or _sp_oauth_token()`"
+        )
+        assert re.search(r"_sp_oauth_token\(\)\s*or\s*_pat_token\(\)", main_src), (
+            "the CODA_MODEL_AUTH=sp branch should be the inverse"
+        )
+
+
+class TestProxyAgrees:
+    """content_filter_proxy signs OpenCode / Hermes / Codex. If it disagreed with
+    the helper, those agents would be attributed to a different identity than
+    Claude and pi on the same box."""
+
+    def test_proxy_uses_the_shared_preference_helper(self):
+        src = (REPO_ROOT / "content_filter_proxy.py").read_text()
+        assert "prefer_pat_for_model_auth" in src, (
+            "the proxy must consult token_helper.prefer_pat_for_model_auth() "
+            "rather than hardcoding an order"
+        )
+
+    def test_proxy_prefers_pat_by_default(self, tmp_path, monkeypatch):
+        import content_filter_proxy as cfp
+
+        cfg = tmp_path / ".databrickscfg"
+        cfg.write_text("[DEFAULT]\nhost = https://x\ntoken = pat-from-cfg\n")
+        monkeypatch.setattr(cfp, "_DATABRICKSCFG_PATH", str(cfg))
+        monkeypatch.setattr(cfp, "_TOKEN_CACHE", {"token": None, "read_at": 0.0, "mtime": 0.0})
+        monkeypatch.setattr(cfp, "resolve_sp_oauth_token", lambda: "sp-tok")
+        monkeypatch.setattr(cfp, "resolve_databricks_token", lambda: None)
+
+        assert cfp._get_fresh_token() == "pat-from-cfg"
+
+    def test_proxy_prefers_sp_when_selected(self, tmp_path, monkeypatch):
+        import content_filter_proxy as cfp
+
+        monkeypatch.setenv("CODA_MODEL_AUTH", "sp")
+        cfg = tmp_path / ".databrickscfg"
+        cfg.write_text("[DEFAULT]\nhost = https://x\ntoken = pat-from-cfg\n")
+        monkeypatch.setattr(cfp, "_DATABRICKSCFG_PATH", str(cfg))
+        monkeypatch.setattr(cfp, "_TOKEN_CACHE", {"token": None, "read_at": 0.0, "mtime": 0.0})
+        monkeypatch.setattr(cfp, "resolve_sp_oauth_token", lambda: "sp-tok")
+        monkeypatch.setattr(cfp, "resolve_databricks_token", lambda: None)
+
+        assert cfp._get_fresh_token() == "sp-tok"
+
+    def test_proxy_falls_back_to_sp_when_no_pat(self, tmp_path, monkeypatch):
+        import content_filter_proxy as cfp
+
+        cfg = tmp_path / ".databrickscfg"
+        cfg.write_text("[DEFAULT]\nhost = https://x\n")  # no token
+        monkeypatch.setattr(cfp, "_DATABRICKSCFG_PATH", str(cfg))
+        monkeypatch.setattr(cfp, "_TOKEN_CACHE", {"token": None, "read_at": 0.0, "mtime": 0.0})
+        monkeypatch.setattr(cfp, "resolve_sp_oauth_token", lambda: "sp-tok")
+        monkeypatch.setattr(cfp, "resolve_databricks_token", lambda: None)
+
+        assert cfp._get_fresh_token() == "sp-tok"
+
+
+class TestDeployedConfigMatchesIntent:
+    def test_app_yaml_selects_pat_and_leaves_sp_helper_off(self):
+        yaml = pytest.importorskip("yaml")
+        env = {
+            e["name"]: e.get("value")
+            for e in yaml.safe_load((REPO_ROOT / "app.yaml").read_text())["env"]
+        }
+        assert env.get("CODA_MODEL_AUTH") == "pat"
+        assert "ENABLE_SP_APIKEYHELPER" not in env, (
+            "ENABLE_SP_APIKEYHELPER should stay commented out: it attributes model "
+            "inference to the service principal instead of the user"
+        )
+
+    def test_app_yaml_is_single_user(self):
+        yaml = pytest.importorskip("yaml")
+        env = {
+            e["name"]: e.get("value")
+            for e in yaml.safe_load((REPO_ROOT / "app.yaml").read_text())["env"]
+        }
+        assert "CODA_DISABLE_OWNER_CHECK" not in env, (
+            "shared-app mode must stay off: it lets any workspace user drive the "
+            "terminal as the single injected identity, which defeats attributing "
+            "agent actions to a real user"
+        )

--- a/tests/test_omnigents_host_api.py
+++ b/tests/test_omnigents_host_api.py
@@ -155,3 +155,80 @@ def test_omnigent_host_share_explicit_grant_user(monkeypatch):
     assert resp.status_code == 200
     assert captured["grant_user"] == "teammate@example.com"
     assert captured["launch"] is False
+
+
+# ---------------------------------------------------------------------------
+# Owner gating on the host-share endpoint
+# ---------------------------------------------------------------------------
+#
+# This endpoint acts with the app SP's authority: it grants another identity
+# `use` on an SP-owned Omnigent host. It is NOT covered by _owner_check_disabled
+# (the shared-app opt-out only opens the terminal + WebSocket), and app.yaml has
+# always promised "configure-pat and omnigent-host/share stay owner-only".
+#
+# It previously gated itself with `if _is_databricks_apps() and app_owner:`,
+# which short-circuits to *allow* when app_owner is None — so a transient
+# Apps-API failure at boot left it ungated. Unlike configure-pat there is no
+# bootstrap justification here, so it must fail CLOSED.
+
+
+def _share_request(app_module, *, owner, caller):
+    original = app_module.app_owner
+    try:
+        app_module.app_owner = owner
+        with app_module.app.test_client() as client:
+            with mock.patch.object(app_module, "_is_databricks_apps", return_value=True):
+                return client.post(
+                    "/api/omnigent-host/share",
+                    json={},
+                    headers={"X-Forwarded-Email": caller} if caller else {},
+                )
+    finally:
+        app_module.app_owner = original
+
+
+def test_host_share_denied_when_owner_unresolved():
+    """Must fail closed, not fall through to acting with SP authority."""
+    app_module = _import_app()
+
+    resp = _share_request(app_module, owner=None, caller="anyone@example.com")
+
+    assert resp.status_code == 403, (
+        f"host-share must deny when app_owner is unresolved, got {resp.status_code}"
+    )
+
+
+def test_host_share_denied_for_non_owner():
+    app_module = _import_app()
+
+    resp = _share_request(
+        app_module, owner="owner@example.com", caller="intruder@example.com"
+    )
+
+    assert resp.status_code == 403
+
+
+def test_host_share_denied_when_owner_unresolved_even_in_shared_mode(monkeypatch):
+    """The shared-app opt-out must not widen this endpoint."""
+    monkeypatch.setenv("CODA_DISABLE_OWNER_CHECK", "true")
+    app_module = _import_app()
+
+    resp = _share_request(app_module, owner=None, caller="anyone@example.com")
+
+    assert resp.status_code == 403, (
+        "CODA_DISABLE_OWNER_CHECK only opens the terminal + WebSocket; owner-only "
+        f"write endpoints must stay gated, got {resp.status_code}"
+    )
+
+
+def test_host_share_allowed_for_owner_reaches_handler():
+    """Sanity check that the gate isn't simply denying everything."""
+    app_module = _import_app()
+
+    resp = _share_request(
+        app_module, owner="owner@example.com", caller="owner@example.com"
+    )
+
+    # No server URL configured, so the handler itself rejects with 400 — the
+    # point is that it got past the owner gate rather than 403-ing.
+    assert resp.status_code != 403

--- a/token_helper.py
+++ b/token_helper.py
@@ -6,13 +6,23 @@ this helper *per request / per TTL*. Centralising the writer keeps a single
 source of truth for the token-resolution logic and its interpreter wiring, so
 the two agents can never drift apart.
 
-The helper prints exactly one line to stdout: the bearer token. Resolution
-order (see the emitted script's docstring for the full rationale):
-  1. SP OAuth token fetched from the loopback broker (host path).
-  2. Legacy ``omnigents-host`` M2M profile, for upgrades from older containers.
-  3. The PAT from ``$DATABRICKS_TOKEN`` or ``~/.databrickscfg`` [DEFAULT].
-All are resolved fresh on each invocation, so a long-running agent survives
-PAT rotation / SP-OAuth expiry without a restart.
+The helper prints exactly one line to stdout: the bearer token.
+
+Which identity is preferred is set by ``CODA_MODEL_AUTH``:
+
+  pat (default)
+      The user's PAT (``$DATABRICKS_TOKEN`` or ``~/.databrickscfg`` [DEFAULT]),
+      falling back to SP OAuth. Model inference is then attributed to the real
+      user, so AI Gateway usage tracking, cost attribution and per-user
+      governance all work — matching the identity the shell/CLI already uses.
+  sp
+      SP OAuth from the loopback broker (then the legacy ``omnigents-host`` M2M
+      profile), falling back to the PAT. Buys zero-PAT onboarding at the cost of
+      attributing every agent's model calls to one service principal.
+
+Whichever is preferred, the other is the fallback — a misconfiguration degrades
+instead of breaking. All sources are resolved fresh on each invocation, so a
+long-running agent survives PAT rotation / SP-OAuth expiry without a restart.
 """
 
 import configparser
@@ -25,6 +35,22 @@ from urllib.request import urlopen
 # Legacy SP OAuth profile name. New installs persist only a secret-free host
 # pointer under this name and fetch bearers from the loopback broker.
 SP_PROFILE = "omnigents-host"
+
+# Preferred identity for agent model calls. Kept here so the proxy
+# (content_filter_proxy) and the emitted helper script agree — having the two
+# disagree would mean browser-terminal agents and proxied agents ran as different
+# identities, which is exactly the drift this module exists to prevent.
+MODEL_AUTH_ENV = "CODA_MODEL_AUTH"
+
+
+def prefer_pat_for_model_auth() -> bool:
+    """True when model calls should be signed with the user's PAT.
+
+    Defaults to True: a real user identity is the desired posture, and it matches
+    what the shell/CLI already does. Set CODA_MODEL_AUTH=sp to prefer the app
+    service principal instead.
+    """
+    return os.environ.get(MODEL_AUTH_ENV, "pat").strip().lower() != "sp"
 
 
 def resolve_sp_oauth_token() -> str | None:
@@ -50,12 +76,11 @@ def resolve_sp_oauth_token() -> str | None:
     return None
 
 
-def resolve_databricks_token() -> str | None:
-    """Resolve a fresh SP OAuth token, falling back to the current PAT."""
-    token = resolve_sp_oauth_token()
-    if token:
-        return token
+def resolve_pat() -> str | None:
+    """The current user PAT, from the environment or ~/.databrickscfg [DEFAULT].
 
+    Read fresh (never cached) because the rotator rewrites the file every ~10 min.
+    """
     token = os.environ.get("DATABRICKS_TOKEN", "").strip()
     if token:
         return token
@@ -65,6 +90,17 @@ def resolve_databricks_token() -> str | None:
         return config.get("DEFAULT", "token", fallback="").strip() or None
     except Exception:
         return None
+
+
+def resolve_databricks_token() -> str | None:
+    """Resolve a model-auth bearer, honouring CODA_MODEL_AUTH.
+
+    Returns the preferred identity's token, the other one if the preferred is
+    unavailable, or None if neither is.
+    """
+    if prefer_pat_for_model_auth():
+        return resolve_pat() or resolve_sp_oauth_token()
+    return resolve_sp_oauth_token() or resolve_pat()
 
 _HELPER_SRC = '''#!/usr/bin/env python3
 """Print a Databricks bearer token for Claude Code / Pi token resolution.
@@ -153,10 +189,25 @@ def _pat_token():
         return None
 
 
+def _prefer_pat():
+    """Mirror of token_helper.prefer_pat_for_model_auth().
+
+    This script runs as a standalone subprocess per request, so it cannot import
+    the parent module -- the check is duplicated deliberately. Keep the two in
+    sync; tests/test_model_auth_priority.py asserts they agree.
+    """
+    return os.environ.get("CODA_MODEL_AUTH", "pat").strip().lower() != "sp"
+
+
 def main():
-    token = _sp_oauth_token() or _pat_token()
+    # Preferred identity first, the other as fallback, so a missing PAT (or a
+    # missing broker) degrades instead of failing outright.
+    if _prefer_pat():
+        token = _pat_token() or _sp_oauth_token()
+    else:
+        token = _sp_oauth_token() or _pat_token()
     if not token:
-        print("no token source (no SP token broker, no PAT)", file=sys.stderr)
+        print("no token source (no PAT, no SP token broker)", file=sys.stderr)
         sys.exit(1)
     sys.stdout.write(token)
 


### PR DESCRIPTION
Two related changes, plus a fail-open gate they exposed.

## 1. Model inference is attributed to the user, not the app SP

Agents already acted as the real user for everything they *did* — git, the databricks CLI, file writes all use the injected PAT. **Model calls were signed with the app service principal**, so all AI Gateway usage, cost attribution and per-user governance collapsed onto one identity: every agent on every box looked like the same principal.

`CODA_MODEL_AUTH` now selects the identity, defaulting to **`pat`**. `sp` restores the old behaviour (zero-PAT onboarding, single attributed identity). The non-preferred one is always the fallback, so a missing PAT degrades rather than breaks.

> **Flipping `ENABLE_SP_APIKEYHELPER` alone would not have done this.** Neither `token_helper.resolve_sp_oauth_token()` nor `content_filter_proxy._get_fresh_token()` consulted any flag — they preferred the SP unconditionally whenever a broker URL or the `omnigents-host` profile existed. The switch had to go into the resolvers.

Three independent paths honour it, and the point of `tests/test_model_auth_priority.py` is that they **can't drift**:

1. `token_helper.resolve_databricks_token()` — in-process
2. The **emitted helper script** — runs standalone per request (Claude Code `apiKeyHelper`, pi `!command`), so it can't import the parent module and duplicates the check. Tests assert the duplicate reads the same env var, with the same default, and orders its fallbacks identically.
3. `content_filter_proxy._get_fresh_token()` — OpenCode / Hermes / Codex

If those disagreed, agents on one box would run as different identities depending on which you launched — the same shape as the OpenCode `auth.json` bug, where a writer and a rotator quietly diverged.

An unrecognised `CODA_MODEL_AUTH` value resolves to `pat`, so a typo can't silently hand model calls to the SP.

## 2. Single-user by default

`CODA_DISABLE_OWNER_CHECK` is commented out. Shared mode attributes every action to the one injected identity rather than the person typing — which defeats §1. Worth stating plainly: **PAT-primary does not give per-attendee identity in shared mode.**

## 3. The fail-open gate this exposed

Restoring the owner check makes `check_authorization()`'s fail-closed path reachable again — which made an existing inconsistency matter. `configure_pat()` and `omnigent-host/share` both gated themselves with:

```python
if _is_databricks_apps() and app_owner:   # ← allows when app_owner is None
```

So a transient Apps-API failure at boot left **both ungated**, and any workspace-SSO'd user could submit their own PAT and persistently impersonate the owner — the exact vector the comment above `configure_pat` describes. `app.yaml` has always promised *"configure-pat and omnigent-host/share stay owner-only"*; that didn't hold when owner resolution failed.

Both now route through one `_require_owner()` helper that fails closed.

### One deliberate exception — and a test that was right

`tests/test_auth_enforcement.py` already asserted configure-pat must **not** 403 while the owner is unresolved, because owner resolution can itself depend on a PAT (`get_token_owner` tier 2 calls `current_user.me()`) — requiring an owner to accept a PAT would **deadlock bootstrap**.

My first pass broke that test and I nearly "fixed" the test. The test was right. So the allowance is kept but narrowed to the case that needs it: an unresolved owner is tolerated **only while no PAT is configured**, it logs loudly that whoever arrives first can claim the app, and `APP_OWNER_EMAIL` closes the window entirely. `host-share` has no bootstrap justification and fails closed unconditionally.

The SP is still used for the Omnigent host tunnel, which **cannot** use a PAT (the Apps proxy rejects them).

## Verification

**589 passed, 3 skipped.** Each new guard mutation-checked by reintroducing the bug.

Worth flagging: the first mutation — reinstating the fail-open `host-share` gate — **was not caught** by the suite as it stood. That's why `tests/test_omnigents_host_api.py` grew explicit owner-gating tests, including one asserting `CODA_DISABLE_OWNER_CHECK` cannot widen that endpoint.

`docs/auth-and-identity.md` and the README env table updated, including the shared-mode attribution caveat.

⚠️ Behavioural change: agents now need a PAT for model calls on a deploy that previously relied on the SP helper. Not deploy-verified.