### PR TITLE
test(skill): add live CoDA core-contract verifier for coda-main

### DIFF
--- a/.claude/skills/verify-coda-live/SKILL.md
+++ b/.claude/skills/verify-coda-live/SKILL.md
@@ -1,0 +1,438 @@
+---
+name: verify-coda-live
+description: Use after merging CoDA PRs, before a release, or when asked whether coda-main still works. Drives coda-main through an authenticated Chrome session and CoDA's JSON terminal API, runs the structured scripts/verify_coda_live.py smoke test, and returns evidence for SP-authenticated Pi/OpenCode inference, live workspace model-catalog parity, GitHub CLI access, and Databricks CLI workspace read/write access. Can switch coda-main's git-linked deployment branch and always restores it.
+---
+
+# Verify CoDA live on `coda-main`
+
+This is the release smoke test for CoDA's base contract after a batch of merges.
+It is deliberately executable by a cheaper agent: the decisions and shell logic
+live in `scripts/verify_coda_live.py`; the agent only deploys, opens the page,
+starts one terminal session through JSON APIs, and reports the resulting JSON.
+
+## Required contract
+
+A run passes only when all three hold:
+
+1. **Agent inference / model discovery**
+   - Pi and OpenCode both make a real model call through Unity AI Gateway.
+   - The token used by Pi's helper identifies as the **app service principal**
+     when `--expect-model-auth sp` is selected.
+   - No user PAT is present for the SP-only baseline.
+   - Each agent's configured model catalog exactly matches the compatible READY
+     serving endpoints in the active workspace:
+       - Pi: READY `databricks-claude-*` endpoints.
+       - OpenCode: READY `databricks-claude-*`, `databricks-gemini-*`, and
+         `databricks-gpt-*` endpoints.
+     Extra stale models and missing active models both fail the run.
+2. **GitHub**
+   - `gh auth status` succeeds.
+   - `gh api user` resolves a login.
+   - `gh repo view databrickslabs/coding-agents-databricks-apps` succeeds and
+     reports viewer permission.
+   - Plain git can `ls-remote` main over HTTPS (proves gh/git credential wiring,
+     not only the gh API).
+3. **Databricks workspace**
+   - `databricks current-user me` succeeds and reports the effective identity.
+   - `databricks serving-endpoints list` succeeds.
+   - A unique file can be created under `/Shared/coda-live-smoke-*`, exported
+     byte-for-byte, and deleted. The verifier cleans it in `finally` even when
+     an intermediate step fails.
+
+The two inference prompts request one fixed marker each (`CODA_PI_OK`,
+`CODA_OPENCODE_OK`) and enable no tools, so token/cost usage is minimal.
+
+---
+
+## Non-negotiable safety rules
+
+- Target **`coda-main` only**. Never deploy, stop, start, or restart `coda`.
+- Never request, paste, echo, print, or retrieve a PAT/client secret. The verifier
+  reports only booleans, profile names, and `/Me` identity fields.
+- Do not scrape xterm's canvas. Terminal output must come from `/api/output`.
+- Do not use raw curl against the app URL. The Apps proxy returns `302 → OIDC`
+  before the request reaches CoDA. Use `fetch()` from the authenticated page.
+- If the page shows login, stop and ask the operator to authenticate.
+- If changing the deployed branch, record the starting branch/commit and restore
+  it at the end even after a failed test.
+- Do not claim PASS from local tests or config inspection. Only the live JSON
+  report counts.
+
+---
+
+## Phase 0 — identify and, if needed, deploy the target
+
+Read the current deployment:
+
+```bash
+databricks apps get coda-main --profile daveok --output json
+```
+
+Record:
+
+- `active_deployment.git_source.branch`
+- `active_deployment.git_source.resolved_commit`
+- `active_deployment.status.state`
+
+Choose the branch under test:
+
+- After this skill/script is merged, normally use `main`.
+- Before merge, use the PR branch containing
+  `scripts/verify_coda_live.py` (currently `docs/verify-live-skill`).
+- To validate another branch, it must include the verifier script or be rebased
+  onto a commit that does.
+
+`coda-main` is git-linked. Change only the git reference; repository URL/provider
+are configured at app level and the API rejects them in the deploy request:
+
+```bash
+cat >/tmp/coda-verify-deploy.json <<'JSON'
+{
+  "mode": "SNAPSHOT",
+  "git_source": {"branch": "BRANCH_UNDER_TEST"}
+}
+JSON
+
+databricks apps deploy coda-main \
+  --profile daveok \
+  --json @/tmp/coda-verify-deploy.json \
+  --output json
+```
+
+Require `status.state == "SUCCEEDED"`. Record the resolved commit. If the deploy
+fails, report the build message and stop; still restore at the end.
+
+Immediately inspect boot logs before markers roll off the short tail:
+
+```bash
+databricks apps logs coda-main --profile daveok
+```
+
+For the expected SP baseline, require:
+
+- `Owner resolved from app.creator: ...`
+- `SP token broker listening on loopback`
+- `SP apikeyhelper: setup triggered at boot (no PAT paste needed)`
+
+These two build errors are expected when optional Omnigent resources are not
+attached and do **not** fail deployment:
+
+- `error resolving resource omnigent-server-url ... not found`
+- `error resolving resource omnigent-wheels ... not found`
+
+Wait until the app is ACTIVE:
+
+```bash
+databricks apps get coda-main --profile daveok --output json
+```
+
+---
+
+## Phase 1 — attach to the authenticated Chrome page
+
+Use Chrome DevTools tools, not curl.
+
+1. `chrome_devtools_list_pages`
+2. Select the page whose URL begins:
+   `https://coda-main-7405618534560628.8.azure.databricksapps.com`
+3. If absent, `chrome_devtools_new_page` with that URL.
+4. If a login/consent page appears, stop and ask the operator to finish login.
+
+Confirm authenticated access from inside the page:
+
+```js
+async () => {
+  const r = await fetch('/api/setup-status');
+  return {status: r.status, body: await r.text()};
+}
+```
+
+Require HTTP 200. Parse the body and report every setup step whose status is not
+`complete`. A still-running step can be polled for up to 10 minutes. Any `error`
+step is a failed smoke test.
+
+Also record:
+
+```js
+async () => (await fetch('/api/pat-status')).json()
+```
+
+For `--expect-model-auth sp`, require no configured user PAT. This establishes
+that successful inference cannot be accidentally attributed to a pasted PAT.
+
+---
+
+## Phase 2 — create one terminal session through the JSON API
+
+Create the session:
+
+```js
+async () => {
+  const r = await fetch('/api/session', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({label: 'coda-live-verifier'})
+  });
+  const body = await r.json();
+  window.__codaVerify = {
+    sessionId: body.session_id,
+    output: '',
+    begin: '__CODA_VERIFY_BEGIN__',
+    end: '__CODA_VERIFY_END__'
+  };
+  return {status: r.status, body};
+}
+```
+
+Require a `session_id`. Wait 2 seconds for the shell, then send the verifier.
+The command never emits a token. It writes JSON to a temp file, prints it between
+markers, and prints the exit code:
+
+```js
+async () => {
+  const s = window.__codaVerify;
+  const command = [
+    "uv run --project /app/python/source_code python /app/python/source_code/scripts/verify_coda_live.py",
+    "  --expect-model-auth sp",
+    "  >/tmp/coda-live-report.json 2>/tmp/coda-live-error.txt; rc=$?;",
+    "printf '\\n__CODA_VERIFY_BEGIN__\\n';",
+    "if [ -s /tmp/coda-live-report.json ]; then cat /tmp/coda-live-report.json;",
+    "else printf '{\"ok\":false,\"failures\":[\"verifier crashed\"],\"stderr\":';",
+    "python3 -c 'import json;print(json.dumps(open(\"/tmp/coda-live-error.txt\").read()))';",
+    "printf '}'; fi;",
+    "printf '\\n__CODA_VERIFY_END__\\n__CODA_VERIFY_RC__:%s\\n' \"$rc\""
+  ].join(' ');
+  const r = await fetch('/api/input', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({session_id: s.sessionId, input: command + '\n'})
+  });
+  return {status: r.status, body: await r.text()};
+}
+```
+
+### Poll output without canvas scraping
+
+`/api/output` **drains** the session buffer. Accumulate every chunk in a page
+global. Use this 15-second poll repeatedly until `done` is true; model calls can
+take a few minutes:
+
+```js
+async () => {
+  const s = window.__codaVerify;
+  for (let i = 0; i < 15; i++) {
+    const r = await fetch('/api/output', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({session_id: s.sessionId})
+    });
+    const body = await r.json();
+    s.output += body.output || '';
+    if (s.output.includes(s.end)) break;
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+  const begin = s.output.indexOf(s.begin);
+  const end = s.output.indexOf(s.end);
+  const reportText = begin >= 0 && end > begin
+    ? s.output.slice(begin + s.begin.length, end).trim()
+    : null;
+  const rcMatch = s.output.match(/__CODA_VERIFY_RC__:(\d+)/);
+  return {
+    done: end >= 0,
+    rc: rcMatch ? Number(rcMatch[1]) : null,
+    reportText,
+    tail: s.output.slice(-2000)
+  };
+}
+```
+
+When `done` is true, parse `reportText` as JSON. If parsing fails, return the raw
+text and tail; do not invent a result.
+
+---
+
+## Phase 3 — interpret the structured report
+
+The verifier exits 0 only when every required lane passes. Still inspect the
+fields; the failures are more valuable than the summary boolean.
+
+### A. SP auth and model inference
+
+Require:
+
+```text
+auth_material.default_pat_present == false
+auth_material.broker_url_present == true
+model_token_identity.classified_as == "service_principal"
+model_token_identity.ok == true
+inference.pi.ok == true
+inference.pi.marker_seen == true
+inference.opencode.ok == true
+inference.opencode.marker_seen == true
+```
+
+`model_token_identity` executes Pi's configured helper command, keeps the bearer
+only in memory, calls workspace SCIM `/Me`, and returns identity fields — never
+the token. This is direct evidence that Pi's model token is the SP, not inference
+from config flags.
+
+For OpenCode, the content-filter proxy obtains the same brokered SP source. With
+no PAT present, a successful OpenCode marker is evidence that the SP path works.
+
+### B. Workspace model catalog parity
+
+Require all three:
+
+```text
+model_catalogs.pi.exact_match == true
+model_catalogs.opencode.exact_match == true
+model_catalogs.opencode.cli_display_exact_match == true
+```
+
+The third assertion runs `opencode models databricks` and
+`opencode models databricks-openai` and checks what the CLI **actually displays**,
+not just what `opencode.json` contains.
+
+Inspect all four sets:
+
+- `configured`
+- `expected_ready_compatible`
+- `extra_not_ready`
+- `missing_ready`
+- for OpenCode: `cli_displayed`, `cli_display_extra`, `cli_display_missing`
+
+Any model in `extra_not_ready` means the picker advertises something the active
+workspace does not serve. Any model in `missing_ready` means an active compatible
+model is absent from the picker. Do not waive one direction.
+
+This check may expose a real issue: current Pi setup historically wrote only one
+active model into `models.json`. If the workspace serves several Claude models,
+Pi will fail exact parity. Report that as a product bug; do not weaken the test.
+
+Also require:
+
+```text
+model_catalogs.pi.uses_gateway_route == true
+model_catalogs.pi.api_key_is_helper_command == true
+model_catalogs.opencode.uses_proxy_or_gateway == true
+```
+
+### C. GitHub
+
+Require:
+
+```text
+github.ok == true
+github.login is non-empty
+github.repo.nameWithOwner == "databrickslabs/coding-agents-databricks-apps"
+github.git_ls_remote_main == true
+```
+
+This is read-only. It proves gh API auth plus plain git credential-helper wiring.
+Do not push, create issues, merge PRs, or mutate repository state.
+
+### D. Databricks workspace
+
+Require:
+
+```text
+databricks_cli.command_ok == true
+workspace_models.command_ok == true
+workspace_round_trip.ok == true
+workspace_round_trip.round_trip_equal == true
+all workspace_round_trip.steps.*.ok == true
+```
+
+The unique `/Shared/coda-live-smoke-*` path must be deleted. If cleanup failed,
+report the exact path prominently so an operator can remove it.
+
+---
+
+## Phase 4 — cleanup and restore
+
+Close the terminal session:
+
+```js
+async () => {
+  const s = window.__codaVerify;
+  if (!s || !s.sessionId) return {skipped: true};
+  const r = await fetch('/api/session/close', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({session_id: s.sessionId})
+  });
+  return {status: r.status, body: await r.text()};
+}
+```
+
+If the deployed branch was changed, always restore the branch recorded in Phase
+0. Usually that is `main`:
+
+```bash
+cat >/tmp/coda-verify-restore.json <<'JSON'
+{
+  "mode": "SNAPSHOT",
+  "git_source": {"branch": "main"}
+}
+JSON
+
+databricks apps deploy coda-main \
+  --profile daveok \
+  --json @/tmp/coda-verify-restore.json \
+  --output json
+```
+
+Confirm restore status SUCCEEDED and `coda-main` ACTIVE.
+
+---
+
+## Fast diagnostic modes
+
+Useful while iterating on the verifier, but **not sufficient for release PASS**:
+
+- `--skip-inference`: no model calls; validates auth material, catalogs, gh and
+  Databricks workspace operations.
+- `--skip-workspace-write`: avoids the `/Shared` round-trip.
+- `--expect-model-auth pat`: verifies a PAT-based branch instead of SP baseline.
+
+For a real smoke test, use no skip flags.
+
+---
+
+## Suggested extended checks (not release blockers yet)
+
+Run these after the base contract is stable:
+
+1. **Session lifecycle:** detach/reattach and confirm buffered output replay.
+2. **PAT fallback:** with an operator-provided short-lived PAT, rerun using
+   `--expect-model-auth pat`; never have the agent handle the PAT.
+3. **Cold boot:** stop/start `coda-main` and repeat, proving installs don't rely
+   on cached binaries from an earlier deployment.
+4. **Gateway attribution:** inspect AI Gateway usage for the two marker calls and
+   confirm the principal is the expected app SP.
+5. **Git write in a disposable repo:** create a temporary branch/commit/push only
+   when explicitly authorized; read-only gh/git is the default smoke test.
+6. **Unity Catalog:** create/read/drop a uniquely named table or volume under a
+   dedicated smoke-test schema, if the app SP is supposed to have those grants.
+7. **Owner security:** confirm a non-owner cannot create a terminal session or
+   invoke owner-only endpoints in single-user mode.
+
+---
+
+## Required report format
+
+Return one concise report with:
+
+1. App, deployed branch, resolved commit, deployment status.
+2. Setup steps not complete.
+3. SP-auth evidence (no PAT, broker present, `/Me` classified SP).
+4. Pi inference result + selected model.
+5. OpenCode inference result + selected model.
+6. Pi and OpenCode catalog parity — list extras and missing models explicitly.
+7. GitHub login, viewer permission, and git ls-remote result.
+8. Databricks CLI identity and workspace round-trip result.
+9. Cleanup and branch-restore result.
+10. Overall PASS/FAIL, copying the verifier's `failures` array verbatim.
+
+Never collapse a failed subcheck into "mostly works." The purpose is to find the
+regression surface created by the merge batch.

--- a/scripts/verify_coda_live.py
+++ b/scripts/verify_coda_live.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""Structured, secret-safe live smoke test for a deployed CoDA container.
+
+Run *inside* the CoDA terminal. Intended to be driven through CoDA's authenticated
+JSON terminal API by the verify-coda-live skill, not by scraping xterm's canvas.
+
+Checks the product contract:
+  1. Pi and OpenCode can infer through Unity AI Gateway with app-SP auth.
+  2. Their advertised model catalogs match compatible READY serving endpoints.
+  3. GitHub CLI authentication and safe repository reads work.
+  4. Databricks CLI authentication and a safe /Shared write/read/delete round-trip work.
+
+Outputs one JSON document. It never prints a bearer token, PAT, client secret, or
+auth.json contents. Exit 0 = all required checks passed; exit 1 = one or more failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+HOME = Path(os.environ.get("HOME") or "/app/python/source_code")
+APP_ROOT = Path(__file__).resolve().parent.parent
+PI_CONFIG = HOME / ".pi" / "agent" / "models.json"
+OPENCODE_CONFIG = HOME / ".config" / "opencode" / "opencode.json"
+DATABRICKS_CFG = HOME / ".databrickscfg"
+REPO = "databrickslabs/coding-agents-databricks-apps"
+
+# These are the model families the current CoDA configs know how to drive.
+# Custom serving endpoints are deliberately excluded from exact catalog parity:
+# setup_pi.py only configures Anthropic wire format, and setup_opencode.py only
+# registers the Databricks Claude/Gemini and GPT providers below.
+PI_PREFIXES = ("databricks-claude-",)
+OPENCODE_PREFIXES = ("databricks-claude-", "databricks-gemini-", "databricks-gpt-")
+
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _clean(text: str, limit: int = 20_000) -> str:
+    """Remove terminal control codes and cap output. Never use for a token."""
+    text = ANSI_RE.sub("", text or "")
+    return text[-limit:]
+
+
+def run(cmd: list[str], *, timeout: int = 60, env: dict[str, str] | None = None) -> dict[str, Any]:
+    """Run a command, returning JSON-safe evidence rather than raising."""
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+            cwd=str(HOME),
+        )
+        return {
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "stdout": _clean(proc.stdout),
+            "stderr": _clean(proc.stderr),
+            "command": [cmd[0], *["<prompt>" if i == len(cmd) - 1 and len(cmd) > 2 else x for i, x in enumerate(cmd[1:], 1)]],
+        }
+    except FileNotFoundError:
+        return {"ok": False, "returncode": None, "stdout": "", "stderr": f"{cmd[0]} not installed", "command": [cmd[0]]}
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "ok": False,
+            "returncode": None,
+            "stdout": _clean((exc.stdout or "") if isinstance(exc.stdout, str) else ""),
+            "stderr": f"timed out after {timeout}s",
+            "command": [cmd[0]],
+        }
+    except Exception as exc:  # noqa: BLE001 — verifier reports, never hides
+        return {"ok": False, "returncode": None, "stdout": "", "stderr": f"{type(exc).__name__}: {exc}", "command": [cmd[0]]}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text())
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def parse_json_output(result: dict[str, Any]) -> Any:
+    if not result.get("ok"):
+        return None
+    try:
+        return json.loads(result.get("stdout") or "")
+    except Exception:
+        return None
+
+
+def ready_endpoints(raw: Any) -> list[str]:
+    """READY endpoint names from CLI JSON (dict or list shape)."""
+    if isinstance(raw, dict):
+        endpoints = raw.get("endpoints") or []
+    elif isinstance(raw, list):
+        endpoints = raw
+    else:
+        endpoints = []
+    names: list[str] = []
+    for endpoint in endpoints:
+        if not isinstance(endpoint, dict):
+            continue
+        state = endpoint.get("state") or {}
+        ready = str(state.get("ready") or "").upper()
+        name = endpoint.get("name")
+        if name and ready == "READY":
+            names.append(str(name))
+    return sorted(set(names))
+
+
+def profile_summary() -> dict[str, Any]:
+    cp = configparser.ConfigParser()
+    try:
+        cp.read(DATABRICKS_CFG)
+    except Exception:
+        pass
+    profiles = cp.sections()
+    default = cp["DEFAULT"] if "DEFAULT" in cp else {}
+    return {
+        "file_exists": DATABRICKS_CFG.exists(),
+        "profiles": profiles,
+        "default_pat_present": bool((default.get("token") or "").strip()),
+        "sp_profile_present": "omnigents-host" in profiles,
+        "broker_url_present": bool(os.environ.get("CODA_SP_TOKEN_BROKER_URL", "").strip()),
+        "sp_client_secret_visible": bool(os.environ.get("DATABRICKS_CLIENT_SECRET", "").strip()),
+    }
+
+
+def databricks_identity() -> tuple[dict[str, Any], Any]:
+    result = run(["databricks", "current-user", "me", "--output", "json"], timeout=30)
+    parsed = parse_json_output(result)
+    evidence = {
+        "command_ok": result["ok"],
+        "returncode": result["returncode"],
+        "stderr": result["stderr"],
+        "identity": parsed,
+    }
+    return evidence, parsed
+
+
+def serving_model_evidence() -> tuple[dict[str, Any], list[str]]:
+    result = run(["databricks", "serving-endpoints", "list", "--output", "json"], timeout=45)
+    parsed = parse_json_output(result)
+    ready = ready_endpoints(parsed)
+    return {
+        "command_ok": result["ok"],
+        "returncode": result["returncode"],
+        "stderr": result["stderr"],
+        "ready_endpoint_names": ready,
+    }, ready
+
+
+def pi_models(config: dict[str, Any]) -> list[str]:
+    provider = ((config.get("providers") or {}).get("databricks-claude") or {})
+    models = provider.get("models") or []
+    return sorted({str(m.get("id")) for m in models if isinstance(m, dict) and m.get("id")})
+
+
+def opencode_models(config: dict[str, Any]) -> list[str]:
+    providers = config.get("provider") or {}
+    names: set[str] = set()
+    for provider_name in ("databricks", "databricks-openai"):
+        models = ((providers.get(provider_name) or {}).get("models") or {})
+        if isinstance(models, dict):
+            names.update(str(x) for x in models)
+    return sorted(names)
+
+
+def opencode_displayed_models() -> dict[str, Any]:
+    """What `opencode models` actually displays, not only what its JSON says."""
+    results = {
+        "databricks": run(["opencode", "models", "databricks"], timeout=45),
+        "databricks-openai": run(["opencode", "models", "databricks-openai"], timeout=45),
+    }
+    displayed: set[str] = set()
+    # Current CLI output is one `provider/model-id` per line. Be tolerant of
+    # surrounding decoration while still requiring the configured provider id.
+    pattern = re.compile(r"(?:^|\s)(databricks(?:-openai)?)/([^\s]+)")
+    for result in results.values():
+        for match in pattern.finditer(result.get("stdout") or ""):
+            displayed.add(match.group(2).strip())
+    return {
+        "command_ok": all(r["ok"] for r in results.values()),
+        "models": sorted(displayed),
+        "errors": [r["stderr"] for r in results.values() if not r["ok"]],
+    }
+
+
+def catalog_comparison(ready: list[str]) -> dict[str, Any]:
+    pi_cfg = load_json(PI_CONFIG)
+    oc_cfg = load_json(OPENCODE_CONFIG)
+    pi_configured = pi_models(pi_cfg)
+    oc_configured = opencode_models(oc_cfg)
+    oc_display = opencode_displayed_models()
+    pi_expected = sorted(n for n in ready if n.startswith(PI_PREFIXES))
+    oc_expected = sorted(n for n in ready if n.startswith(OPENCODE_PREFIXES))
+
+    pi_provider = ((pi_cfg.get("providers") or {}).get("databricks-claude") or {})
+    oc_providers = oc_cfg.get("provider") or {}
+    pi_base = str(pi_provider.get("baseUrl") or "")
+    oc_db_base = str((((oc_providers.get("databricks") or {}).get("options") or {}).get("baseURL") or ""))
+    oc_openai_base = str((((oc_providers.get("databricks-openai") or {}).get("options") or {}).get("baseURL") or ""))
+
+    def compare(configured: list[str], expected: list[str]) -> dict[str, Any]:
+        extra = sorted(set(configured) - set(expected))
+        missing = sorted(set(expected) - set(configured))
+        return {
+            "configured": configured,
+            "expected_ready_compatible": expected,
+            "extra_not_ready": extra,
+            "missing_ready": missing,
+            "exact_match": not extra and not missing,
+        }
+
+    return {
+        "pi": {
+            **compare(pi_configured, pi_expected),
+            "config_exists": PI_CONFIG.exists(),
+            "base_url": pi_base,
+            "uses_gateway_route": "ai-gateway" in pi_base or pi_base.startswith("http://127.0.0.1:"),
+            "api_key_is_helper_command": str(pi_provider.get("apiKey") or "").startswith("!"),
+        },
+        "opencode": {
+            **compare(oc_configured, oc_expected),
+            "config_exists": OPENCODE_CONFIG.exists(),
+            "databricks_base_url": oc_db_base,
+            "openai_base_url": oc_openai_base,
+            "uses_proxy_or_gateway": oc_db_base.startswith("http://127.0.0.1:") and (not oc_openai_base or "ai-gateway" in oc_openai_base),
+            "cli_model_command_ok": oc_display["command_ok"],
+            "cli_displayed": oc_display["models"],
+            "cli_display_extra": sorted(set(oc_display["models"]) - set(oc_expected)),
+            "cli_display_missing": sorted(set(oc_expected) - set(oc_display["models"])),
+            "cli_display_exact_match": (
+                oc_display["command_ok"]
+                and set(oc_display["models"]) == set(oc_expected)
+            ),
+            "cli_errors": oc_display["errors"],
+        },
+    }
+
+
+def token_identity_from_pi_helper() -> dict[str, Any]:
+    """Resolve Pi's helper token in memory and call SCIM /Me; never print token."""
+    cfg = load_json(PI_CONFIG)
+    provider = ((cfg.get("providers") or {}).get("databricks-claude") or {})
+    command = str(provider.get("apiKey") or "")
+    if not command.startswith("!"):
+        return {"ok": False, "reason": "Pi apiKey is not a helper command"}
+    try:
+        token_proc = subprocess.run(
+            shlex.split(command[1:]), capture_output=True, text=True, timeout=20, cwd=str(HOME)
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"ok": False, "reason": f"helper failed: {type(exc).__name__}: {exc}"}
+    token = (token_proc.stdout or "").strip()
+    if token_proc.returncode != 0 or not token:
+        return {"ok": False, "reason": _clean(token_proc.stderr) or "helper returned no token"}
+
+    host = os.environ.get("DATABRICKS_HOST", "").rstrip("/")
+    if not host:
+        return {"ok": False, "reason": "DATABRICKS_HOST absent"}
+    req = urllib.request.Request(
+        f"{host}/api/2.0/preview/scim/v2/Me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as response:
+            body = json.loads(response.read().decode())
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as exc:
+        return {"ok": False, "reason": f"SCIM /Me failed: {type(exc).__name__}: {exc}"}
+    finally:
+        token = ""  # do not retain it longer than needed
+
+    username = str(body.get("userName") or "")
+    app_id = str(body.get("applicationId") or "")
+    classified = "user" if "@" in username else "service_principal"
+    return {
+        "ok": True,
+        "classified_as": classified,
+        "userName": username,
+        "displayName": body.get("displayName"),
+        "applicationId": app_id or None,
+        "id": body.get("id"),
+    }
+
+
+def inference_checks(catalogs: dict[str, Any], *, skip: bool) -> dict[str, Any]:
+    if skip:
+        return {"skipped": True, "reason": "--skip-inference"}
+
+    result: dict[str, Any] = {}
+    pi_models_list = catalogs["pi"]["configured"]
+    if pi_models_list:
+        model = pi_models_list[0]
+        pi = run(
+            [
+                "pi", "--print", "--no-session", "--no-tools", "--no-context-files",
+                "--no-extensions", "--no-skills", "--model",
+                f"databricks-claude/{model}",
+                "Reply with exactly CODA_PI_OK",
+            ],
+            timeout=150,
+        )
+        result["pi"] = {
+            "ok": pi["ok"] and "CODA_PI_OK" in pi["stdout"],
+            "model": model,
+            "marker_seen": "CODA_PI_OK" in pi["stdout"],
+            "returncode": pi["returncode"],
+            "stdout": pi["stdout"],
+            "stderr": pi["stderr"],
+        }
+    else:
+        result["pi"] = {"ok": False, "reason": "no configured Pi model"}
+
+    oc_models_list = catalogs["opencode"]["configured"]
+    claude_like = [x for x in oc_models_list if x.startswith(("databricks-claude-", "databricks-gemini-"))]
+    if claude_like:
+        model = claude_like[0]
+        oc = run(
+            ["opencode", "run", "--pure", "--format", "json", "--model", f"databricks/{model}", "Reply with exactly CODA_OPENCODE_OK"],
+            timeout=180,
+        )
+        result["opencode"] = {
+            "ok": oc["ok"] and "CODA_OPENCODE_OK" in oc["stdout"],
+            "model": model,
+            "marker_seen": "CODA_OPENCODE_OK" in oc["stdout"],
+            "returncode": oc["returncode"],
+            "stdout": oc["stdout"],
+            "stderr": oc["stderr"],
+        }
+    else:
+        result["opencode"] = {"ok": False, "reason": "no configured OpenCode databricks model"}
+    return result
+
+
+def github_checks() -> dict[str, Any]:
+    status = run(["gh", "auth", "status", "--hostname", "github.com"], timeout=20)
+    user = run(["gh", "api", "user", "--jq", ".login"], timeout=20)
+    repo = run(["gh", "repo", "view", REPO, "--json", "nameWithOwner,viewerPermission,isPrivate"], timeout=30)
+    ls_remote = run(["git", "ls-remote", "--heads", f"https://github.com/{REPO}.git", "main"], timeout=30)
+    return {
+        "ok": all(x["ok"] for x in (status, user, repo, ls_remote)),
+        "auth_status": {"ok": status["ok"], "stderr": status["stderr"]},
+        "login": user["stdout"].strip() if user["ok"] else None,
+        "repo": parse_json_output(repo),
+        "git_ls_remote_main": ls_remote["ok"],
+        "errors": [x["stderr"] for x in (status, user, repo, ls_remote) if not x["ok"]],
+    }
+
+
+def workspace_round_trip(*, skip: bool) -> dict[str, Any]:
+    if skip:
+        return {"skipped": True, "reason": "--skip-workspace-write"}
+    unique = f"/Shared/coda-live-smoke-{int(time.time())}-{uuid.uuid4().hex[:6]}"
+    with tempfile.TemporaryDirectory(prefix="coda-live-") as temp_dir:
+        src = Path(temp_dir) / "probe.txt"
+        dst = Path(temp_dir) / "exported.txt"
+        content = f"coda smoke {uuid.uuid4()}\n"
+        src.write_text(content)
+        steps: dict[str, Any] = {}
+        try:
+            steps["mkdirs"] = run(["databricks", "workspace", "mkdirs", unique], timeout=30)
+            steps["import"] = run(
+                ["databricks", "workspace", "import", f"{unique}/probe.txt", "--file", str(src), "--format", "RAW", "--overwrite"],
+                timeout=30,
+            )
+            steps["get_status"] = run(
+                ["databricks", "workspace", "get-status", f"{unique}/probe.txt", "--output", "json"],
+                timeout=30,
+            )
+            steps["export"] = run(
+                ["databricks", "workspace", "export", f"{unique}/probe.txt", "--format", "RAW", "--file", str(dst)],
+                timeout=30,
+            )
+            round_trip_equal = dst.exists() and dst.read_text() == content
+        finally:
+            steps["cleanup"] = run(
+                ["databricks", "workspace", "delete", unique, "--recursive"], timeout=30
+            )
+        required = ("mkdirs", "import", "get_status", "export", "cleanup")
+        return {
+            "ok": all(steps[k]["ok"] for k in required) and round_trip_equal,
+            "workspace_path": unique,
+            "round_trip_equal": round_trip_equal,
+            "steps": {
+                k: {"ok": v["ok"], "returncode": v["returncode"], "stderr": v["stderr"]}
+                for k, v in steps.items()
+            },
+        }
+
+
+def required_failures(report: dict[str, Any], expected_auth: str) -> list[str]:
+    failures: list[str] = []
+    profiles = report["auth_material"]
+    if expected_auth == "sp":
+        if not profiles["broker_url_present"]:
+            failures.append("SP broker URL absent")
+        if profiles["default_pat_present"]:
+            failures.append("PAT present while testing SP-only baseline")
+        if report["model_token_identity"].get("classified_as") != "service_principal":
+            failures.append("Pi helper token did not identify as a service principal")
+    elif expected_auth == "pat":
+        if not profiles["default_pat_present"]:
+            failures.append("PAT absent while testing PAT baseline")
+        if report["model_token_identity"].get("classified_as") != "user":
+            failures.append("Pi helper token did not identify as a user")
+
+    if not report["databricks_cli"]["command_ok"]:
+        failures.append("databricks current-user me failed")
+    for agent in ("pi", "opencode"):
+        catalog = report["model_catalogs"][agent]
+        if not catalog["exact_match"]:
+            failures.append(f"{agent} model catalog does not exactly match READY compatible endpoints")
+        if not catalog.get("config_exists"):
+            failures.append(f"{agent} config missing")
+    if not report["model_catalogs"]["opencode"].get("cli_display_exact_match"):
+        failures.append("OpenCode displayed model list does not exactly match READY compatible endpoints")
+    inference = report["inference"]
+    if not inference.get("skipped"):
+        for agent in ("pi", "opencode"):
+            if not inference.get(agent, {}).get("ok"):
+                failures.append(f"{agent} inference smoke failed")
+    if not report["github"]["ok"]:
+        failures.append("GitHub CLI/repository read smoke failed")
+    workspace = report["workspace_round_trip"]
+    if not workspace.get("skipped") and not workspace.get("ok"):
+        failures.append("Databricks workspace write/read/delete round-trip failed")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expect-model-auth", choices=("sp", "pat"), default="sp")
+    parser.add_argument("--skip-inference", action="store_true", help="Do not make the two model calls")
+    parser.add_argument("--skip-workspace-write", action="store_true", help="Do not create/delete the /Shared probe")
+    args = parser.parse_args()
+
+    db_identity, _ = databricks_identity()
+    models_evidence, ready = serving_model_evidence()
+    catalogs = catalog_comparison(ready)
+    report: dict[str, Any] = {
+        "contract": {
+            "expected_model_auth": args.expect_model_auth,
+            "target": "deployed CoDA container",
+            "repo_commit": run(["git", "-C", str(APP_ROOT), "rev-parse", "HEAD"], timeout=10)["stdout"].strip(),
+        },
+        "auth_material": profile_summary(),
+        "model_token_identity": token_identity_from_pi_helper(),
+        "databricks_cli": db_identity,
+        "workspace_models": models_evidence,
+        "model_catalogs": catalogs,
+        "inference": inference_checks(catalogs, skip=args.skip_inference),
+        "github": github_checks(),
+        "workspace_round_trip": workspace_round_trip(skip=args.skip_workspace_write),
+    }
+    failures = required_failures(report, args.expect_model_auth)
+    report["failures"] = failures
+    report["ok"] = not failures
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verify_coda_live.py
+++ b/tests/test_verify_coda_live.py
@@ -1,0 +1,192 @@
+"""Unit tests for scripts/verify_coda_live.py's decision logic.
+
+The live commands themselves only count when run inside coda-main. These tests
+hold the parser/comparison/reporting logic so a verifier bug cannot turn a real
+regression into a green report.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "verify_coda_live.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("verify_coda_live", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def verifier():
+    return _load()
+
+
+class TestReadyEndpointParsing:
+    def test_parses_cli_dict_shape_and_only_ready(self, verifier):
+        raw = {
+            "endpoints": [
+                {"name": "databricks-claude-opus-4-8", "state": {"ready": "READY"}},
+                {"name": "databricks-gpt-5", "state": {"ready": "NOT_READY"}},
+                {"name": "custom", "state": {"ready": "READY"}},
+            ]
+        }
+        assert verifier.ready_endpoints(raw) == ["custom", "databricks-claude-opus-4-8"]
+
+    def test_accepts_list_shape(self, verifier):
+        raw = [{"name": "b", "state": {"ready": "READY"}}, {"name": "a", "state": {"ready": "READY"}}]
+        assert verifier.ready_endpoints(raw) == ["a", "b"]
+
+    @pytest.mark.parametrize("raw", [None, {}, [], "garbage"])
+    def test_malformed_or_empty_is_empty(self, verifier, raw):
+        assert verifier.ready_endpoints(raw) == []
+
+
+class TestCatalogExtraction:
+    def test_pi_models(self, verifier):
+        cfg = {
+            "providers": {
+                "databricks-claude": {
+                    "models": [{"id": "b"}, {"id": "a"}, {"other": "ignored"}]
+                }
+            }
+        }
+        assert verifier.pi_models(cfg) == ["a", "b"]
+
+    def test_opencode_combines_databricks_providers(self, verifier):
+        cfg = {
+            "provider": {
+                "databricks": {"models": {"claude": {}}},
+                "databricks-openai": {"models": {"gpt": {}}},
+                "unrelated": {"models": {"must-not-appear": {}}},
+            }
+        }
+        assert verifier.opencode_models(cfg) == ["claude", "gpt"]
+
+
+class TestCatalogParity:
+    def _write_configs(self, verifier, tmp_path, pi, oc):
+        pi_path = tmp_path / "pi.json"
+        oc_path = tmp_path / "oc.json"
+        pi_path.write_text(json.dumps({
+            "providers": {
+                "databricks-claude": {
+                    "baseUrl": "https://x.ai-gateway.test/anthropic",
+                    "apiKey": "!python helper.py",
+                    "models": [{"id": x} for x in pi],
+                }
+            }
+        }))
+        oc_path.write_text(json.dumps({
+            "provider": {
+                "databricks": {
+                    "options": {"baseURL": "http://127.0.0.1:4000"},
+                    "models": {x: {} for x in oc if not x.startswith("databricks-gpt-")},
+                },
+                "databricks-openai": {
+                    "options": {"baseURL": "https://x.ai-gateway.test/openai/v1"},
+                    "models": {x: {} for x in oc if x.startswith("databricks-gpt-")},
+                },
+            }
+        }))
+        verifier.PI_CONFIG = pi_path
+        verifier.OPENCODE_CONFIG = oc_path
+        verifier.opencode_displayed_models = lambda: {
+            "command_ok": True,
+            "models": sorted(oc),
+            "errors": [],
+        }
+
+    def test_exact_match_passes(self, verifier, tmp_path):
+        ready = ["databricks-claude-a", "databricks-gpt-b", "custom-endpoint"]
+        self._write_configs(verifier, tmp_path, ["databricks-claude-a"], ["databricks-claude-a", "databricks-gpt-b"])
+        result = verifier.catalog_comparison(ready)
+        assert result["pi"]["exact_match"] is True
+        assert result["opencode"]["exact_match"] is True
+
+    def test_extra_stale_model_fails(self, verifier, tmp_path):
+        self._write_configs(verifier, tmp_path, ["databricks-claude-old"], [])
+        result = verifier.catalog_comparison(["databricks-claude-live"])
+        assert result["pi"]["extra_not_ready"] == ["databricks-claude-old"]
+        assert result["pi"]["missing_ready"] == ["databricks-claude-live"]
+        assert result["pi"]["exact_match"] is False
+
+    def test_missing_active_model_fails(self, verifier, tmp_path):
+        self._write_configs(verifier, tmp_path, ["databricks-claude-a"], [])
+        result = verifier.catalog_comparison(["databricks-claude-a", "databricks-claude-b"])
+        assert result["pi"]["missing_ready"] == ["databricks-claude-b"]
+
+    def test_custom_endpoint_is_not_expected(self, verifier, tmp_path):
+        self._write_configs(verifier, tmp_path, [], [])
+        result = verifier.catalog_comparison(["my-rag-endpoint", "custom-llama"])
+        assert result["pi"]["expected_ready_compatible"] == []
+        assert result["opencode"]["expected_ready_compatible"] == []
+
+
+class TestFailureAggregation:
+    def _green_report(self):
+        return {
+            "auth_material": {"broker_url_present": True, "default_pat_present": False},
+            "model_token_identity": {"ok": True, "classified_as": "service_principal"},
+            "databricks_cli": {"command_ok": True},
+            "model_catalogs": {
+                "pi": {"exact_match": True, "config_exists": True},
+                "opencode": {
+                    "exact_match": True,
+                    "config_exists": True,
+                    "cli_display_exact_match": True,
+                },
+            },
+            "inference": {"pi": {"ok": True}, "opencode": {"ok": True}},
+            "github": {"ok": True},
+            "workspace_round_trip": {"ok": True},
+        }
+
+    def test_green_report_has_no_failures(self, verifier):
+        assert verifier.required_failures(self._green_report(), "sp") == []
+
+    @pytest.mark.parametrize(
+        "mutate,expected",
+        [
+            (lambda r: r["auth_material"].update(broker_url_present=False), "SP broker URL absent"),
+            (lambda r: r["auth_material"].update(default_pat_present=True), "PAT present while testing SP-only baseline"),
+            (lambda r: r["model_token_identity"].update(classified_as="user"), "Pi helper token did not identify as a service principal"),
+            (lambda r: r["model_catalogs"]["pi"].update(exact_match=False), "pi model catalog does not exactly match READY compatible endpoints"),
+            (lambda r: r["model_catalogs"]["opencode"].update(cli_display_exact_match=False), "OpenCode displayed model list does not exactly match READY compatible endpoints"),
+            (lambda r: r["inference"]["opencode"].update(ok=False), "opencode inference smoke failed"),
+            (lambda r: r["github"].update(ok=False), "GitHub CLI/repository read smoke failed"),
+            (lambda r: r["workspace_round_trip"].update(ok=False), "Databricks workspace write/read/delete round-trip failed"),
+        ],
+    )
+    def test_each_required_lane_can_fail_the_run(self, verifier, mutate, expected):
+        report = self._green_report()
+        mutate(report)
+        assert expected in verifier.required_failures(report, "sp")
+
+
+class TestSecretSafety:
+    def test_source_never_prints_token_value(self):
+        source = SCRIPT.read_text()
+        # A token is held transiently for /Me, but must never enter the report.
+        assert '"token": token' not in source
+        assert "print(token)" not in source
+        # The verifier may say that it does not print auth.json, but it must not
+        # open/read that file (only the non-secret opencode config).
+        assert 'open("auth.json")' not in source
+        assert 'OPENCODE_AUTH' not in source
+
+    def test_reported_auth_material_is_boolean_only(self, verifier, tmp_path):
+        cfg = tmp_path / ".databrickscfg"
+        cfg.write_text("[DEFAULT]\nhost = https://x\ntoken = dapi-super-secret\n")
+        verifier.DATABRICKS_CFG = cfg
+        summary = verifier.profile_summary()
+        assert summary["default_pat_present"] is True
+        assert "dapi-super-secret" not in json.dumps(summary)


### PR DESCRIPTION
## What this is

A delegatable release smoke test for **coda-main** after a batch of merges. A cheaper Chrome-driving agent follows `.claude/skills/verify-coda-live/SKILL.md`; the decisions and shell logic live in `scripts/verify_coda_live.py`, which emits one secret-safe JSON report.

## Required contract

### 1. Pi + OpenCode / Unity AI Gateway / SP auth

- Both make a real one-line marker call (`CODA_PI_OK`, `CODA_OPENCODE_OK`), with no tools.
- No PAT is present; broker URL is present.
- Pi's helper token is held only in memory, used to call SCIM `/Me`, and must identify as **service_principal**. The token is never included in output.
- The catalogs exactly match compatible **READY** workspace endpoints:
  - Pi: `databricks-claude-*`
  - OpenCode: `databricks-claude-*`, `databricks-gemini-*`, `databricks-gpt-*`
- Both directions are strict: stale extras and missing active models fail.
- OpenCode is checked at two levels: `opencode.json` **and what `opencode models databricks[\-openai]` actually displays**.

This may expose a real product bug: Pi historically writes only one active model into `models.json`. If the workspace serves several READY Claude models, exact parity fails. That's intentional — don't weaken the test to hide it.

### 2. GitHub

- `gh auth status`
- `gh api user`
- `gh repo view databrickslabs/coding-agents-databricks-apps` + viewer permission
- plain `git ls-remote` main over HTTPS (proves gh/git credential-helper wiring, not only gh API)

Read-only; no pushes/issues/merges.

### 3. Databricks CLI

- `databricks current-user me`
- serving-endpoint list
- unique `/Shared/coda-live-smoke-*` mkdir/import/export/byte-compare/delete round-trip, with cleanup in `finally`

## Why Chrome + JSON API

Three traps were hit during today's verification work:

1. Raw curl never reaches CoDA — Apps proxy answers `302 -> OIDC` first, even for `/health`.
2. xterm renders to `<canvas>`, so DOM snapshots cannot read command output.
3. `chrome_devtools_evaluate_script` can `fetch()` from the authenticated page, inheriting SSO. The skill uses CoDA's `/api/session`, `/api/input`, `/api/output`, accumulates the draining output buffer until explicit markers arrive, then parses the JSON.

It includes exact JS request bodies, git-linked branch deployment + mandatory restore, boot-log expectations, PAT/secret prohibitions, diagnostic skip modes, and a fixed report format.

## Verification

- verifier produces valid JSON and no token-shaped output outside the container (expected FAIL there)
- **23** verifier-logic tests: endpoint parsing, catalog extraction, exact parity both directions, displayed-model mismatch, every required failure lane, and secret safety
- **584 passed, 1 skipped** deterministic unit suite

⚠️ This PR adds the verifier; it does not claim the live contract passes yet. The point is to deploy this branch to coda-main and let the result tell us what broke.