### PR TITLE
fix(p0): complete broker CLI routing and live verifier

### DIFF
--- a/.claude/skills/verify-coda-live/SKILL.md
+++ b/.claude/skills/verify-coda-live/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-coda-live
-description: Use after merging CoDA PRs, before a release, or when asked whether coda-main still works. Drives coda-main through an authenticated Chrome session and CoDA's JSON terminal API, runs the structured scripts/verify_coda_live.py smoke test, and returns evidence for SP-authenticated Pi/OpenCode inference, live workspace model-catalog parity, GitHub CLI access, and Databricks CLI workspace read/write access. Can switch coda-main's git-linked deployment branch and always restores it.
+description: Use after merging CoDA PRs, before a release, or when asked whether coda-main still works. Drives coda-main through an authenticated Chrome session and CoDA's JSON terminal API, runs the structured scripts/verify_coda_live.py smoke test, and returns evidence for SP-authenticated Claude Code/Pi/OpenCode inference, live workspace model-catalog parity, GitHub CLI access, and Databricks CLI workspace read/write access. Can switch coda-main's git-linked deployment branch and always restores it.
 ---
 
 # Verify CoDA live on `coda-main`
@@ -15,12 +15,15 @@ starts one terminal session through JSON APIs, and reports the resulting JSON.
 A run passes only when all three hold:
 
 1. **Agent inference / model discovery**
-   - Pi and OpenCode both make a real model call through Unity AI Gateway.
+   - Claude Code, Pi and OpenCode all make a real model call through Unity AI
+     Gateway.
    - The token used by Pi's helper identifies as the **app service principal**
      when `--expect-model-auth sp` is selected.
    - No user PAT is present for the SP-only baseline.
    - Each agent's configured model catalog exactly matches the compatible READY
      serving endpoints in the active workspace:
+       - Claude: active `ANTHROPIC_*_MODEL` settings are READY
+         `databricks-claude-*` endpoints.
        - Pi: READY `databricks-claude-*` endpoints.
        - OpenCode: READY `databricks-claude-*`, `databricks-gemini-*`, and
          `databricks-gpt-*` endpoints.
@@ -39,8 +42,9 @@ A run passes only when all three hold:
      byte-for-byte, and deleted. The verifier cleans it in `finally` even when
      an intermediate step fails.
 
-The two inference prompts request one fixed marker each (`CODA_PI_OK`,
-`CODA_OPENCODE_OK`) and enable no tools, so token/cost usage is minimal.
+The three inference prompts request one fixed marker each (`CODA_CLAUDE_OK`,
+`CODA_PI_OK`, `CODA_OPENCODE_OK`) and enable no tools, so token/cost usage is
+minimal.
 
 ---
 
@@ -265,6 +269,8 @@ auth_material.default_pat_present == false
 auth_material.broker_url_present == true
 model_token_identity.classified_as == "service_principal"
 model_token_identity.ok == true
+inference.claude.ok == true
+inference.claude.marker_seen == true
 inference.pi.ok == true
 inference.pi.marker_seen == true
 inference.opencode.ok == true
@@ -426,13 +432,14 @@ Return one concise report with:
 1. App, deployed branch, resolved commit, deployment status.
 2. Setup steps not complete.
 3. SP-auth evidence (no PAT, broker present, `/Me` classified SP).
-4. Pi inference result + selected model.
-5. OpenCode inference result + selected model.
-6. Pi and OpenCode catalog parity — list extras and missing models explicitly.
-7. GitHub login, viewer permission, and git ls-remote result.
-8. Databricks CLI identity and workspace round-trip result.
-9. Cleanup and branch-restore result.
-10. Overall PASS/FAIL, copying the verifier's `failures` array verbatim.
+4. Claude Code inference result + selected model.
+5. Pi inference result + selected model.
+6. OpenCode inference result + selected model.
+7. Claude/Pi/OpenCode catalog parity — list extras and missing models explicitly.
+8. GitHub login, viewer permission, and git ls-remote result.
+9. Databricks CLI identity and workspace round-trip result.
+10. Cleanup and branch-restore result.
+11. Overall PASS/FAIL, copying the verifier's `failures` array verbatim.
 
 Never collapse a failed subcheck into "mostly works." The purpose is to find the
 regression surface created by the merge batch.

--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ import signal
 import time
 import copy
 import logging
+import shutil
 from concurrent.futures import ThreadPoolExecutor, wait
 from flask import Flask, send_from_directory, request, jsonify, session
 from flask_socketio import SocketIO, emit, join_room, leave_room, disconnect
@@ -27,6 +28,7 @@ import app_state
 import enterprise_config
 from claude_otel import apply_claude_otel_env
 from utils import add_1m_context_suffix, ensure_https, get_gateway_host
+from token_helper import write_databricks_token_wrapper
 from pat_rotator import PATRotator
 from sp_token_broker import BROKER_URL_ENV, broker_url, mint_sp_token, start_sp_token_broker
 from telemetry import log_telemetry, set_product_info
@@ -264,6 +266,14 @@ def _run_step(step_id, command):
 
         result = subprocess.run(command, env=env, capture_output=True, text=True, timeout=300)
         if result.returncode == 0:
+            # The profile-backed broker shim is also needed by direct terminal
+            # `databricks` commands, not only Omnigent's SDK model-catalog path.
+            # On a no-Omnigent deploy the host setup never calls its installer,
+            # leaving databricks_cli_path pointing at a missing wrapper and every
+            # workspace CLI call failing with `no cached credentials`. Install it
+            # immediately after the real CLI is available.
+            if step_id == "dbcli" and os.environ.get(BROKER_URL_ENV):
+                _ensure_broker_cli_wrapper()
             _update_step(step_id, status="complete", completed_at=time.time())
         else:
             err = result.stderr.strip() or result.stdout.strip() or "Unknown error"
@@ -272,6 +282,31 @@ def _run_step(step_id, command):
         _update_step(step_id, status="error", completed_at=time.time(), error="Timed out after 300s")
     except Exception as e:
         _update_step(step_id, status="error", completed_at=time.time(), error=str(e))
+
+
+def _ensure_broker_cli_wrapper() -> bool:
+    """Install the broker-aware Databricks CLI shim for terminal commands.
+
+    The SDK honours the absolute `databricks_cli_path` in the omnigents-host
+    profile, but a user typing `databricks ...` resolves through PATH. Put the
+    same shim first in the terminal PATH too. This is needed when
+    ENABLE_SP_APIKEYHELPER is on but Omnigent resources are absent: the broker
+    starts, the profile is written, but the Omnigent host setup (which used to
+    install the shim) is intentionally skipped.
+    """
+    if not os.environ.get(BROKER_URL_ENV, "").strip():
+        return False
+    home = os.environ.get("HOME", "/app/python/source_code")
+    if not home or home == "/":
+        home = "/app/python/source_code"
+    expected = os.path.join(home, ".local", "bin", "databricks")
+    real_cli = expected if os.path.isfile(expected) else shutil.which("databricks")
+    if not real_cli:
+        logger.warning("SP broker is running but Databricks CLI is not installed yet; wrapper deferred")
+        return False
+    wrapper = write_databricks_token_wrapper(os.path.join(home, ".coda-broker-bin"), real_cli)
+    logger.info("Installed broker-aware Databricks CLI wrapper at %s", wrapper)
+    return True
 
 
 def _build_terminal_shell_env(base_env: dict) -> dict:
@@ -327,6 +362,15 @@ def _build_terminal_shell_env(base_env: dict) -> dict:
             )
         ):
             shell_env.pop(key, None)
+
+    # Make the broker shim the direct terminal's first Databricks executable too.
+    # The session creator also prepends this path defensively; doing it here
+    # keeps every caller of the environment builder consistent.
+    if shell_env.get(BROKER_URL_ENV, "").strip():
+        home = shell_env.get("HOME", "/app/python/source_code")
+        broker_bin = os.path.join(home, ".coda-broker-bin")
+        if os.path.isdir(broker_bin):
+            shell_env["PATH"] = f"{broker_bin}:{shell_env.get('PATH', '')}"
 
     return shell_env
 
@@ -1933,9 +1977,16 @@ def create_session():
         # Ensure HOME is set correctly
         if not shell_env.get("HOME") or shell_env["HOME"] == "/":
             shell_env["HOME"] = "/app/python/source_code"
-        # Add ~/.local/bin to PATH for claude command
+        # Add the broker shim before ~/.local/bin when SP helper auth is active,
+        # then the normal CLI/tools. Without this, direct `databricks ...` calls
+        # use the real binary, which has no OAuth cache in the container.
         local_bin = f"{shell_env['HOME']}/.local/bin"
-        shell_env["PATH"] = f"{local_bin}:{shell_env.get('PATH', '')}"
+        broker_bin = f"{shell_env['HOME']}/.coda-broker-bin"
+        path_parts = []
+        if shell_env.get(BROKER_URL_ENV, "").strip() and os.path.isdir(broker_bin):
+            path_parts.append(broker_bin)
+        path_parts.extend([local_bin, shell_env.get("PATH", "")])
+        shell_env["PATH"] = ":".join(part for part in path_parts if part)
 
         # Start shell in ~/projects/ directory
         projects_dir = os.path.join(shell_env["HOME"], "projects")
@@ -2220,6 +2271,9 @@ def initialize_app(local_dev=False):
             lambda: mint_sp_token(_omnigent_sp_creds)
         )
         os.environ[BROKER_URL_ENV] = broker_url(_sp_token_broker_server)
+        # Install immediately when the CLI is already cached; _run_step("dbcli")
+        # retries this after a cold-boot install completes.
+        _ensure_broker_cli_wrapper()
         logger.info("SP token broker listening on loopback")
 
     # The profile retains only the workspace host for Omnigent routing. The

--- a/scripts/verify_coda_live.py
+++ b/scripts/verify_coda_live.py
@@ -35,6 +35,11 @@ from typing import Any
 
 HOME = Path(os.environ.get("HOME") or "/app/python/source_code")
 APP_ROOT = Path(__file__).resolve().parent.parent
+# When invoked as `/app/python/source_code/scripts/verify_coda_live.py`, Python's
+# import root is `scripts/`, not the repo root. Add the root explicitly so the
+# verifier can import token_helper and use the broker for Gateway discovery.
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
 PI_CONFIG = HOME / ".pi" / "agent" / "models.json"
 OPENCODE_CONFIG = HOME / ".config" / "opencode" / "opencode.json"
 CLAUDE_CONFIG = HOME / ".claude" / "settings.json"

--- a/scripts/verify_coda_live.py
+++ b/scripts/verify_coda_live.py
@@ -186,19 +186,28 @@ def gateway_model_ids() -> tuple[bool, list[str], str]:
         token = resolve_databricks_token()
     except Exception as exc:  # noqa: BLE001
         return False, [], f"token resolver: {type(exc).__name__}: {exc}"
-    host = _profile_host()
-    if not host or not token:
-        return False, [], "gateway host or broker token unavailable"
+    # Prefer the exact Gateway base that setup_opencode wrote. The profile host
+    # is the workspace host, not the AI Gateway host; appending /openai/v1/models
+    # there returns an HTML/404 response even while inference works.
+    oc_cfg = load_json(OPENCODE_CONFIG)
+    base = str((((oc_cfg.get("provider") or {}).get("databricks-openai") or {}).get("options") or {}).get("baseURL") or "").rstrip("/")
+    if not base:
+        host = _profile_host()
+        base = f"{host}/openai/v1" if host else ""
+    if not base or not token:
+        return False, [], "Gateway base URL or broker token unavailable"
     req = urllib.request.Request(
-        f"{host}/openai/v1/models",
+        f"{base}/models",
         headers={"Authorization": f"Bearer {token}"},
     )
     try:
         with urllib.request.urlopen(req, timeout=30) as response:
-            body = json.loads(response.read().decode())
+            status = response.status
+            raw = response.read().decode()
+        body = json.loads(raw)
         data = body.get("data") if isinstance(body, dict) else []
         ids = sorted({str(x.get("id")) for x in data if isinstance(x, dict) and x.get("id")})
-        return True, ids, ""
+        return True, ids, f"HTTP {status}"
     except Exception as exc:  # noqa: BLE001
         return False, [], f"{type(exc).__name__}: {exc}"
 

--- a/scripts/verify_coda_live.py
+++ b/scripts/verify_coda_live.py
@@ -162,16 +162,67 @@ def databricks_identity() -> tuple[dict[str, Any], Any]:
     return evidence, parsed
 
 
+def _profile_host() -> str:
+    host = os.environ.get("DATABRICKS_HOST", "").strip().rstrip("/")
+    if host:
+        return host
+    try:
+        cfg = configparser.ConfigParser(interpolation=None)
+        cfg.read(DATABRICKS_CFG)
+        return (cfg.get("omnigents-host", "host", fallback="") or "").strip().rstrip("/")
+    except Exception:
+        return ""
+
+
+def gateway_model_ids() -> tuple[bool, list[str], str]:
+    """Discover active Unity AI Gateway model services via OpenAI /models."""
+    try:
+        from token_helper import resolve_databricks_token
+        token = resolve_databricks_token()
+    except Exception as exc:  # noqa: BLE001
+        return False, [], f"token resolver: {type(exc).__name__}: {exc}"
+    host = _profile_host()
+    if not host or not token:
+        return False, [], "gateway host or broker token unavailable"
+    req = urllib.request.Request(
+        f"{host}/openai/v1/models",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:
+            body = json.loads(response.read().decode())
+        data = body.get("data") if isinstance(body, dict) else []
+        ids = sorted({str(x.get("id")) for x in data if isinstance(x, dict) and x.get("id")})
+        return True, ids, ""
+    except Exception as exc:  # noqa: BLE001
+        return False, [], f"{type(exc).__name__}: {exc}"
+
+
 def serving_model_evidence() -> tuple[dict[str, Any], list[str]]:
     result = run(["databricks", "serving-endpoints", "list", "--output", "json"], timeout=45)
     parsed = parse_json_output(result)
-    ready = ready_endpoints(parsed)
+    serving_ready = ready_endpoints(parsed)
+    if serving_ready:
+        return {
+            "command_ok": result["ok"],
+            "returncode": result["returncode"],
+            "stderr": result["stderr"],
+            "source": "databricks serving-endpoints list",
+            "ready_endpoint_names": serving_ready,
+            "gateway_catalog_used": False,
+        }, serving_ready
+
+    gateway_ok, gateway_ids, gateway_error = gateway_model_ids()
     return {
-        "command_ok": result["ok"],
+        "command_ok": result["ok"] and gateway_ok,
         "returncode": result["returncode"],
         "stderr": result["stderr"],
-        "ready_endpoint_names": ready,
-    }, ready
+        "source": "Unity AI Gateway /openai/v1/models" if gateway_ok else "unavailable",
+        "ready_endpoint_names": gateway_ids,
+        "gateway_catalog_used": gateway_ok,
+        "gateway_error": gateway_error,
+        "serving_endpoints_ready": serving_ready,
+    }, gateway_ids
 
 
 def pi_models(config: dict[str, Any]) -> list[str]:
@@ -345,7 +396,7 @@ def inference_checks(catalogs: dict[str, Any], *, skip: bool) -> dict[str, Any]:
 
     result: dict[str, Any] = {}
     claude = run(
-        ["claude", "--print", "--no-session", "--model", "sonnet", "Reply with exactly CODA_CLAUDE_OK"],
+        ["claude", "--print", "--model", "sonnet", "Reply with exactly CODA_CLAUDE_OK"],
         timeout=180,
     )
     result["claude"] = {

--- a/scripts/verify_coda_live.py
+++ b/scripts/verify_coda_live.py
@@ -119,7 +119,13 @@ def ready_endpoints(raw: Any) -> list[str]:
         if not isinstance(endpoint, dict):
             continue
         state = endpoint.get("state") or {}
-        ready = str(state.get("ready") or "").upper()
+        if isinstance(state, dict):
+            ready = str(state.get("ready") or "").upper()
+        else:
+            # Databricks CLI versions have emitted both {state: {ready: READY}}
+            # and {state: READY}; accept the canonical values, not an assumed
+            # one-version shape.
+            ready = str(state).upper()
         name = endpoint.get("name")
         if name and ready == "READY":
             names.append(str(name))
@@ -296,7 +302,18 @@ def token_identity_from_pi_helper() -> dict[str, Any]:
 
     host = os.environ.get("DATABRICKS_HOST", "").rstrip("/")
     if not host:
-        return {"ok": False, "reason": "DATABRICKS_HOST absent"}
+        # CoDA deliberately strips DATABRICKS_HOST from terminal env. The
+        # broker-owned profile still carries the workspace host; use that for
+        # this verifier's safe /Me request rather than treating correct secret
+        # stripping as an auth failure.
+        try:
+            cfg = configparser.ConfigParser(interpolation=None)
+            cfg.read(DATABRICKS_CFG)
+            host = (cfg.get("omnigents-host", "host", fallback="") or "").rstrip("/")
+        except Exception:
+            host = ""
+    if not host:
+        return {"ok": False, "reason": "DATABRICKS_HOST absent and profile host unavailable"}
     req = urllib.request.Request(
         f"{host}/api/2.0/preview/scim/v2/Me",
         headers={"Authorization": f"Bearer {token}"},
@@ -419,7 +436,7 @@ def workspace_round_trip(*, skip: bool) -> dict[str, Any]:
                 timeout=30,
             )
             steps["export"] = run(
-                ["databricks", "workspace", "export", f"{unique}/probe.txt", "--format", "RAW", "--file", str(dst)],
+                ["databricks", "workspace", "export", f"{unique}/probe.txt", "--format", "AUTO", "--file", str(dst)],
                 timeout=30,
             )
             round_trip_equal = dst.exists() and dst.read_text() == content

--- a/scripts/verify_coda_live.py
+++ b/scripts/verify_coda_live.py
@@ -37,6 +37,7 @@ HOME = Path(os.environ.get("HOME") or "/app/python/source_code")
 APP_ROOT = Path(__file__).resolve().parent.parent
 PI_CONFIG = HOME / ".pi" / "agent" / "models.json"
 OPENCODE_CONFIG = HOME / ".config" / "opencode" / "opencode.json"
+CLAUDE_CONFIG = HOME / ".claude" / "settings.json"
 DATABRICKS_CFG = HOME / ".databrickscfg"
 REPO = "databrickslabs/coding-agents-databricks-apps"
 
@@ -173,6 +174,18 @@ def pi_models(config: dict[str, Any]) -> list[str]:
     return sorted({str(m.get("id")) for m in models if isinstance(m, dict) and m.get("id")})
 
 
+def claude_active_models(config: dict[str, Any]) -> list[str]:
+    env = config.get("env") or {}
+    names = []
+    for key in ("ANTHROPIC_MODEL", "ANTHROPIC_DEFAULT_OPUS_MODEL", "ANTHROPIC_DEFAULT_SONNET_MODEL", "ANTHROPIC_DEFAULT_HAIKU_MODEL"):
+        value = str(env.get(key) or "")
+        # Claude's 1M routing suffix is metadata, not a serving endpoint id.
+        value = re.sub(r"\[1m\]$", "", value)
+        if value:
+            names.append(value)
+    return sorted(set(names))
+
+
 def opencode_models(config: dict[str, Any]) -> list[str]:
     providers = config.get("provider") or {}
     names: set[str] = set()
@@ -206,11 +219,14 @@ def opencode_displayed_models() -> dict[str, Any]:
 def catalog_comparison(ready: list[str]) -> dict[str, Any]:
     pi_cfg = load_json(PI_CONFIG)
     oc_cfg = load_json(OPENCODE_CONFIG)
+    claude_cfg = load_json(CLAUDE_CONFIG)
     pi_configured = pi_models(pi_cfg)
     oc_configured = opencode_models(oc_cfg)
     oc_display = opencode_displayed_models()
+    claude_configured = claude_active_models(claude_cfg)
     pi_expected = sorted(n for n in ready if n.startswith(PI_PREFIXES))
     oc_expected = sorted(n for n in ready if n.startswith(OPENCODE_PREFIXES))
+    claude_expected = sorted(n for n in ready if n.startswith(PI_PREFIXES))
 
     pi_provider = ((pi_cfg.get("providers") or {}).get("databricks-claude") or {})
     oc_providers = oc_cfg.get("provider") or {}
@@ -230,6 +246,11 @@ def catalog_comparison(ready: list[str]) -> dict[str, Any]:
         }
 
     return {
+        "claude": {
+            **compare(claude_configured, claude_expected),
+            "config_exists": CLAUDE_CONFIG.exists(),
+            "api_key_helper_present": bool(claude_cfg.get("apiKeyHelper")),
+        },
         "pi": {
             **compare(pi_configured, pi_expected),
             "config_exists": PI_CONFIG.exists(),
@@ -306,6 +327,18 @@ def inference_checks(catalogs: dict[str, Any], *, skip: bool) -> dict[str, Any]:
         return {"skipped": True, "reason": "--skip-inference"}
 
     result: dict[str, Any] = {}
+    claude = run(
+        ["claude", "--print", "--no-session", "--model", "sonnet", "Reply with exactly CODA_CLAUDE_OK"],
+        timeout=180,
+    )
+    result["claude"] = {
+        "ok": claude["ok"] and "CODA_CLAUDE_OK" in claude["stdout"],
+        "marker_seen": "CODA_CLAUDE_OK" in claude["stdout"],
+        "returncode": claude["returncode"],
+        "stdout": claude["stdout"],
+        "stderr": claude["stderr"],
+    }
+
     pi_models_list = catalogs["pi"]["configured"]
     if pi_models_list:
         model = pi_models_list[0]
@@ -424,7 +457,7 @@ def required_failures(report: dict[str, Any], expected_auth: str) -> list[str]:
 
     if not report["databricks_cli"]["command_ok"]:
         failures.append("databricks current-user me failed")
-    for agent in ("pi", "opencode"):
+    for agent in ("claude", "pi", "opencode"):
         catalog = report["model_catalogs"][agent]
         if not catalog["exact_match"]:
             failures.append(f"{agent} model catalog does not exactly match READY compatible endpoints")
@@ -434,7 +467,7 @@ def required_failures(report: dict[str, Any], expected_auth: str) -> list[str]:
         failures.append("OpenCode displayed model list does not exactly match READY compatible endpoints")
     inference = report["inference"]
     if not inference.get("skipped"):
-        for agent in ("pi", "opencode"):
+        for agent in ("claude", "pi", "opencode"):
             if not inference.get(agent, {}).get("ok"):
                 failures.append(f"{agent} inference smoke failed")
     if not report["github"]["ok"]:

--- a/setup_claude.py
+++ b/setup_claude.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 
 from claude_otel import apply_claude_otel_env
+from token_helper import resolve_databricks_token
 from utils import (
     add_1m_context_suffix,
     discover_serving_endpoints,
@@ -42,8 +43,12 @@ def _write_apikey_helper(claude_dir: Path) -> Path:
 claude_dir = home / ".claude"
 claude_dir.mkdir(exist_ok=True)
 
-# 1. Write settings.json for Databricks model serving (requires DATABRICKS_TOKEN)
-token = os.environ.get("DATABRICKS_TOKEN", "").strip()
+# 1. Write settings.json for Databricks model serving. The SP broker is the
+# primary auth source on the no-PAT baseline; checking only the raw
+# DATABRICKS_TOKEN env var made Claude setup silently skip its config even while
+# brokered SP auth was healthy. Resolve through the same layered source as Pi and
+# OpenCode: SP broker/profile, then user PAT.
+token = resolve_databricks_token() or ""
 if token:
     gateway_host = get_gateway_host()
     databricks_host = ensure_https(os.environ.get("DATABRICKS_HOST", "").rstrip("/"))

--- a/setup_pi.py
+++ b/setup_pi.py
@@ -33,6 +33,7 @@ from utils import (
     get_npm_version,
     pick_in_geo_model,
 )
+from token_helper import resolve_databricks_token
 
 # Opt-out: allow operators to disable Pi bundling without removing the file.
 if os.environ.get("ENABLE_PI", "true").strip().lower() in ("false", "0", "no"):
@@ -46,7 +47,13 @@ if not os.environ.get("HOME") or os.environ["HOME"] == "/":
 home = Path(os.environ["HOME"])
 
 host = os.environ.get("DATABRICKS_HOST", "")
-token = os.environ.get("DATABRICKS_TOKEN", "").strip()
+# The SP broker is the primary auth source on the no-PAT baseline. Checking only
+# DATABRICKS_TOKEN made setup exit 0 before writing models.json even though the
+# broker was healthy — setup-status said `pi: complete`, but Pi was unusable.
+# Resolve through the same layered source as OpenCode/Claude: SP broker/profile,
+# then user PAT. This token is only used during setup; Pi writes a helper command
+# for per-request freshness below.
+token = resolve_databricks_token() or ""
 pi_model = os.environ.get("PI_MODEL", "databricks-claude-opus-4-8")
 
 PI_PACKAGE = "@earendil-works/pi-coding-agent"
@@ -102,7 +109,7 @@ if not host or not token:
 host = ensure_https(host.rstrip("/"))
 
 gateway_host = get_gateway_host()
-gateway_token = os.environ.get("DATABRICKS_TOKEN", "") if gateway_host else ""
+gateway_token = token if gateway_host else ""
 if gateway_host and not gateway_token:
     print("Warning: AI Gateway resolved but DATABRICKS_TOKEN missing, falling back to DATABRICKS_HOST")
     gateway_host = ""

--- a/tests/test_broker_terminal_path.py
+++ b/tests/test_broker_terminal_path.py
@@ -1,0 +1,43 @@
+"""Regression tests for direct Databricks CLI use with the SP broker."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+
+def test_broker_wrapper_is_installed_when_cli_exists(tmp_path, monkeypatch):
+    import app
+
+    real_cli = tmp_path / ".local" / "bin" / "databricks"
+    real_cli.parent.mkdir(parents=True)
+    real_cli.write_text("#!/bin/sh\nexit 0\n")
+    real_cli.chmod(0o700)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(app.BROKER_URL_ENV, "http://127.0.0.1:12345/token")
+
+    with mock.patch.object(app, "write_databricks_token_wrapper") as write:
+        write.side_effect = lambda directory, cli: Path(directory).mkdir(parents=True, exist_ok=True) or Path(directory) / "databricks"
+        assert app._ensure_broker_cli_wrapper() is True
+
+    write.assert_called_once_with(str(tmp_path / ".coda-broker-bin"), str(real_cli))
+
+
+def test_terminal_env_puts_broker_before_real_cli(tmp_path, monkeypatch):
+    import app
+
+    broker = tmp_path / ".coda-broker-bin"
+    broker.mkdir()
+    (broker / "databricks").write_text("shim")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(app.BROKER_URL_ENV, "http://127.0.0.1:12345/token")
+    monkeypatch.setenv("ENABLE_SP_APIKEYHELPER", "true")
+    monkeypatch.setenv("PATH", "/system/bin")
+
+    env = app._build_terminal_shell_env(dict(os.environ))
+    # The endpoint's session wrapper adds ~/.local/bin after this helper; the
+    # broker bin must already be first in the shell environment.
+    assert env["PATH"].split(":")[0] == str(broker)
+    assert "DATABRICKS_TOKEN" not in env
+    assert "DATABRICKS_HOST" not in env

--- a/tests/test_setup_pi.py
+++ b/tests/test_setup_pi.py
@@ -12,6 +12,8 @@ import os
 import stat
 import subprocess
 import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest
@@ -104,9 +106,42 @@ class TestSetupPiConfig:
         assert result.returncode == 0
         assert not (tmp_path / ".pi" / "agent" / "models.json").exists()
 
-    def test_no_token_installs_but_skips_config(self, tmp_path):
+    def test_no_token_and_no_broker_installs_but_skips_config(self, tmp_path):
         _seed_fake_pi_binary(tmp_path)
-        result = run_setup_pi(tmp_path, {"DATABRICKS_TOKEN": ""})
+        result = run_setup_pi(tmp_path, {"DATABRICKS_TOKEN": "", "CODA_SP_TOKEN_BROKER_URL": ""})
         assert result.returncode == 0
-        # Config write is gated on a token; without one, no models.json.
+        # No auth source at all still skips config; this is distinct from the
+        # SP-broker case below.
         assert not (tmp_path / ".pi" / "agent" / "models.json").exists()
+
+    def test_sp_broker_token_allows_config_without_pat(self, tmp_path):
+        """SP baseline: Pi setup must not gate models.json on raw
+        DATABRICKS_TOKEN. The broker is the auth source when no PAT exists."""
+        _seed_fake_pi_binary(tmp_path)
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802
+                body = b"sp-token-for-setup"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            result = run_setup_pi(tmp_path, {
+                "DATABRICKS_TOKEN": "",
+                "CODA_SP_TOKEN_BROKER_URL": f"http://127.0.0.1:{server.server_port}/token",
+            })
+        finally:
+            server.shutdown()
+            thread.join(timeout=2)
+
+        assert result.returncode == 0, result.stderr
+        config = read_models(tmp_path)
+        assert config["providers"]["databricks-claude"]["apiKey"].startswith("!")

--- a/tests/test_sp_token_broker.py
+++ b/tests/test_sp_token_broker.py
@@ -91,6 +91,44 @@ def test_databricks_wrapper_intercepts_only_broker_profile(tmp_path):
         server.server_close()
 
 
+def test_databricks_wrapper_routes_direct_profile_commands_through_broker(tmp_path):
+    """A terminal user types `databricks current-user me`, not `auth token`.
+    The shim must inject the broker token into the delegated real CLI for the
+    secret-free omnigents-host profile, otherwise the real CLI searches for a
+    nonexistent OAuth cache."""
+    server = broker.start_sp_token_broker(lambda: "direct-command-token", port=0)
+    try:
+        real_cli = tmp_path / "real-databricks"
+        real_cli.write_text(
+            "#!/bin/sh\n"
+            "printf 'TOKEN=%s HOST=%s ARGS=%s\\n' \"$DATABRICKS_TOKEN\" \"$DATABRICKS_HOST\" \"$*\"\n"
+        )
+        real_cli.chmod(0o700)
+        cfg = tmp_path / ".databrickscfg"
+        cfg.write_text(
+            "[omnigents-host]\n"
+            "host = https://workspace.example\n"
+            "auth_type = databricks-cli\n"
+        )
+        wrapper = write_databricks_token_wrapper(tmp_path / "bin", str(real_cli))
+        env = dict(
+            os.environ,
+            HOME=str(tmp_path),
+            CODA_SP_TOKEN_BROKER_URL=broker.broker_url(server),
+            DATABRICKS_CONFIG_PROFILE="omnigents-host",
+        )
+        result = subprocess.run(
+            [str(wrapper), "current-user", "me"],
+            env=env, capture_output=True, text=True, check=True,
+        )
+        assert "TOKEN=direct-command-token" in result.stdout
+        assert "HOST=https://workspace.example" in result.stdout
+        assert "ARGS=current-user me" in result.stdout
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
 class _Response:
     def __init__(self, body):
         self.body = body

--- a/tests/test_verify_coda_live.py
+++ b/tests/test_verify_coda_live.py
@@ -45,6 +45,9 @@ class TestReadyEndpointParsing:
         raw = [{"name": "b", "state": {"ready": "READY"}}, {"name": "a", "state": {"ready": "READY"}}]
         assert verifier.ready_endpoints(raw) == ["a", "b"]
 
+    def test_accepts_flat_state_shape(self, verifier):
+        assert verifier.ready_endpoints({"endpoints": [{"name": "a", "state": "READY"}]}) == ["a"]
+
     @pytest.mark.parametrize("raw", [None, {}, [], "garbage"])
     def test_malformed_or_empty_is_empty(self, verifier, raw):
         assert verifier.ready_endpoints(raw) == []

--- a/tests/test_verify_coda_live.py
+++ b/tests/test_verify_coda_live.py
@@ -71,6 +71,13 @@ class TestCatalogExtraction:
         }
         assert verifier.opencode_models(cfg) == ["claude", "gpt"]
 
+    def test_claude_models_strips_1m_suffix(self, verifier, tmp_path):
+        cfg = {"env": {
+            "ANTHROPIC_MODEL": "databricks-claude-opus-4-8",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "databricks-claude-opus-4-8[1m]",
+        }}
+        assert verifier.claude_active_models(cfg) == ["databricks-claude-opus-4-8"]
+
 
 class TestCatalogParity:
     def _write_configs(self, verifier, tmp_path, pi, oc):
@@ -138,6 +145,7 @@ class TestFailureAggregation:
             "model_token_identity": {"ok": True, "classified_as": "service_principal"},
             "databricks_cli": {"command_ok": True},
             "model_catalogs": {
+                "claude": {"exact_match": True, "config_exists": True},
                 "pi": {"exact_match": True, "config_exists": True},
                 "opencode": {
                     "exact_match": True,
@@ -145,7 +153,7 @@ class TestFailureAggregation:
                     "cli_display_exact_match": True,
                 },
             },
-            "inference": {"pi": {"ok": True}, "opencode": {"ok": True}},
+            "inference": {"claude": {"ok": True}, "pi": {"ok": True}, "opencode": {"ok": True}},
             "github": {"ok": True},
             "workspace_round_trip": {"ok": True},
         }
@@ -159,6 +167,7 @@ class TestFailureAggregation:
             (lambda r: r["auth_material"].update(broker_url_present=False), "SP broker URL absent"),
             (lambda r: r["auth_material"].update(default_pat_present=True), "PAT present while testing SP-only baseline"),
             (lambda r: r["model_token_identity"].update(classified_as="user"), "Pi helper token did not identify as a service principal"),
+            (lambda r: r["model_catalogs"]["claude"].update(exact_match=False), "claude model catalog does not exactly match READY compatible endpoints"),
             (lambda r: r["model_catalogs"]["pi"].update(exact_match=False), "pi model catalog does not exactly match READY compatible endpoints"),
             (lambda r: r["model_catalogs"]["opencode"].update(cli_display_exact_match=False), "OpenCode displayed model list does not exactly match READY compatible endpoints"),
             (lambda r: r["inference"]["opencode"].update(ok=False), "opencode inference smoke failed"),

--- a/token_helper.py
+++ b/token_helper.py
@@ -209,6 +209,7 @@ def write_databricks_token_wrapper(target_dir, real_cli: str) -> Path:
     target_dir.mkdir(parents=True, exist_ok=True)
     wrapper_path = target_dir / "databricks"
     source = f'''#!{sys.executable}
+import configparser
 import datetime
 import json
 import os
@@ -228,11 +229,34 @@ def _profile(args):
     return None
 
 
-args = sys.argv[1:]
-if args[:2] == ["auth", "token"] and _profile(args) == PROFILE:
+def _broker_token():
     url = os.environ.get("CODA_SP_TOKEN_BROKER_URL", "")
-    with urlopen(url, timeout=5) as response:
-        token = response.read().decode().strip()
+    if not url:
+        return None
+    try:
+        with urlopen(url, timeout=5) as response:
+            token = response.read().decode().strip()
+        return token or None
+    except Exception:
+        return None
+
+
+def _profile_host():
+    path = os.path.expanduser("~/.databrickscfg")
+    try:
+        cfg = configparser.ConfigParser(interpolation=None)
+        cfg.read(path)
+        return (cfg.get(PROFILE, "host", fallback="") or "").strip()
+    except Exception:
+        return ""
+
+
+args = sys.argv[1:]
+profile = _profile(args) or os.environ.get("DATABRICKS_CONFIG_PROFILE")
+if args[:2] == ["auth", "token"] and _profile(args) == PROFILE:
+    token = _broker_token()
+    if not token:
+        os.execv(REAL_CLI, [REAL_CLI, *args])
     # Emit the FULL OAuth token shape the databricks-sdk CLI token source
     # (DatabricksCliTokenSource) requires: access_token + token_type + expiry.
     # ALWAYS emit JSON — NOT gated on `--output json`. The SDK builds the token
@@ -265,6 +289,23 @@ if args[:2] == ["auth", "token"] and _profile(args) == PROFILE:
     # by the SDK, so we don't special-case it.
     print(json.dumps(payload))
     raise SystemExit(0)
+
+# Direct terminal commands (e.g. `databricks current-user me`) do not invoke
+# the SDK's `auth token` subcommand, so they would otherwise reach the real CLI
+# with the secret-free omnigents-host profile and fail looking for an OAuth
+# cache. For that one profile, mint a broker token and hand it to the real CLI
+# through process-local env vars. The token never enters the shell's exported
+# environment or a file, and other profiles/commands are delegated untouched.
+if profile == PROFILE:
+    token = _broker_token()
+    if token:
+        env = dict(os.environ)
+        env["DATABRICKS_TOKEN"] = token
+        host = _profile_host()
+        if host:
+            env["DATABRICKS_HOST"] = host
+        env.pop("DATABRICKS_CONFIG_PROFILE", None)
+        os.execve(REAL_CLI, [REAL_CLI, *args], env)
 
 os.execv(REAL_CLI, [REAL_CLI, *args])
 '''

--- a/token_helper.py
+++ b/token_helper.py
@@ -38,6 +38,18 @@ def resolve_sp_oauth_token() -> str | None:
                 return token
         except Exception:
             pass
+    # Do not let a missing legacy profile trigger the SDK's ambient auth
+    # discovery/network path. On local setup tests (and on a cold PAT-only
+    # container) there is no profile; return immediately so setup scripts can
+    # use DATABRICKS_TOKEN instead of hanging for an unavailable SP login.
+    cfg_path = Path(os.path.expanduser("~/.databrickscfg"))
+    try:
+        config = configparser.ConfigParser()
+        config.read(cfg_path)
+        if SP_PROFILE not in config:
+            return None
+    except Exception:
+        return None
     try:
         from databricks.sdk.core import Config
         headers = Config(profile=SP_PROFILE).authenticate()


### PR DESCRIPTION
Follow-up to #127, which landed the broker-aware Pi/Claude setup and initial terminal shim.

The first live rerun proved Pi inference and setup now work, but found two remaining issues:

1. Direct `databricks current-user me` still failed because the shim only intercepted the SDK's `auth token` command. A user typing a normal Databricks command delegated to the real CLI with the secret-free `omnigents-host` profile, which searched for an OAuth cache. The shim now injects a fresh broker token + profile host into the delegated process-local environment for that profile, and the terminal prepends the shim.
2. The verifier had remaining live assumptions: Claude's CLI doesn't support `--no-session`; Unity AI Gateway model discovery is separate from Model Serving endpoints; `/api/output` marker parsing needed the last marker due PTY echo; and the verifier's absolute script path needed the repo root on sys.path.

## Final live evidence on this branch

Against `coda-main` through authenticated Chrome + the JSON terminal API:

- Claude marker: `CODA_CLAUDE_OK` — PASS
- Pi marker: `CODA_PI_OK` — PASS
- OpenCode marker: `CODA_OPENCODE_OK` — PASS
- `databricks current-user me`: app service principal — PASS
- `/Shared` mkdir/import/status/export/byte-compare/delete — PASS
- Pi config exists — PASS
- broker URL/profile/client secret safety — PASS

The verifier still reports two environment/product gaps rather than hiding them:

- `gh` is installed but no GitHub credential source is configured in the app container; it requires operator-provided `GH_TOKEN` or login.
- Unity AI Gateway `/openai/v1/models` returns HTTP 400 and Model Serving list is empty; inference works, but authoritative active-model catalog parity remains unproven and is reported as failure.

## Verification

591 deterministic tests pass, install dry-run passes, and the same Chrome-driven live skill was rerun after deployment. This PR contains the direct CLI P0 fix plus verifier corrections only.
