### PR TITLE
fix(pi): expose the full Claude picker and verify model switching

### DIFF
--- a/.claude/skills/verify-coda-live/SKILL.md
+++ b/.claude/skills/verify-coda-live/SKILL.md
@@ -42,9 +42,10 @@ A run passes only when all three hold:
      byte-for-byte, and deleted. The verifier cleans it in `finally` even when
      an intermediate step fails.
 
-The three inference prompts request one fixed marker each (`CODA_CLAUDE_OK`,
-`CODA_PI_OK`, `CODA_OPENCODE_OK`) and enable no tools, so token/cost usage is
-minimal.
+The inference prompts request fixed markers (`CODA_CLAUDE_OK`, `CODA_PI_OK`,
+`CODA_OPENCODE_OK`) and enable no tools, so token/cost usage is minimal. Pi also
+runs a second configured model with `CODA_PI_SWITCH_OK` to prove `--model` switching
+works rather than only the default.
 
 ---
 
@@ -276,6 +277,8 @@ inference.claude.ok == true
 inference.claude.marker_seen == true
 inference.pi.ok == true
 inference.pi.marker_seen == true
+inference.pi_switch.ok == true
+inference.pi_switch.marker_seen == true
 inference.opencode.ok == true
 inference.opencode.marker_seen == true
 ```

--- a/scripts/verify_coda_live.py
+++ b/scripts/verify_coda_live.py
@@ -441,6 +441,27 @@ def inference_checks(catalogs: dict[str, Any], *, skip: bool) -> dict[str, Any]:
             "stdout": pi["stdout"],
             "stderr": pi["stderr"],
         }
+        alternate = next((x for x in pi_models_list if x != model), None)
+        if alternate:
+            switched = run(
+                [
+                    "pi", "--print", "--no-session", "--no-tools", "--no-context-files",
+                    "--no-extensions", "--no-skills", "--model",
+                    f"databricks-claude/{alternate}",
+                    "Reply with exactly CODA_PI_SWITCH_OK",
+                ],
+                timeout=150,
+            )
+            result["pi_switch"] = {
+                "ok": switched["ok"] and "CODA_PI_SWITCH_OK" in switched["stdout"],
+                "model": alternate,
+                "marker_seen": "CODA_PI_SWITCH_OK" in switched["stdout"],
+                "returncode": switched["returncode"],
+                "stdout": switched["stdout"],
+                "stderr": switched["stderr"],
+            }
+        else:
+            result["pi_switch"] = {"ok": False, "reason": "only one Pi model configured"}
     else:
         result["pi"] = {"ok": False, "reason": "no configured Pi model"}
 
@@ -552,6 +573,8 @@ def required_failures(report: dict[str, Any], expected_auth: str) -> list[str]:
         for agent in ("claude", "pi", "opencode"):
             if not inference.get(agent, {}).get("ok"):
                 failures.append(f"{agent} inference smoke failed")
+        if not inference.get("pi_switch", {}).get("ok"):
+            failures.append("Pi model switch smoke failed")
     if not report["github"]["ok"]:
         failures.append("GitHub CLI/repository read smoke failed")
     workspace = report["workspace_round_trip"]

--- a/setup_pi.py
+++ b/setup_pi.py
@@ -141,8 +141,32 @@ if os.environ.get("MLFLOW_OSS_TRACKING_ENABLED", "false").lower() == "true":
 available = discover_serving_endpoints(host, token)
 if available:
     print(f"Discovered {len(available)} READY serving endpoints at workspace")
+
+# Keep the whole compatible Claude picker, not just the selected default. Pi's
+# old config wrote one model, so Ctrl+P / --model could not switch even though
+# the Gateway served other Claude models. When endpoint discovery is available,
+# filter this list to READY endpoints; when discovery is unavailable, preserve
+# the known candidate list rather than silently collapsing the picker to one
+# model. The live verifier reports parity separately instead of treating that
+# fallback as proof of availability.
+pi_candidates = [
+    pi_model,
+    "databricks-claude-haiku-4-5",
+    "databricks-claude-opus-4-8",
+    "databricks-claude-opus-4-7",
+    "databricks-claude-opus-4-6",
+    "databricks-claude-sonnet-4-6",
+    "databricks-claude-sonnet-4-5",
+]
+# Preserve order while removing duplicate PI_MODEL entries.
+pi_candidates = list(dict.fromkeys(pi_candidates))
+if available:
+    served_candidates = [m for m in pi_candidates if m in available]
+    model_picker = served_candidates or [pi_model]
+else:
+    model_picker = pi_candidates
 active_model = pick_in_geo_model(
-    [pi_model, "databricks-claude-opus-4-7", "databricks-claude-opus-4-6", "databricks-claude-sonnet-4-6"],
+    pi_candidates,
     available,
     fallback=pi_model,
 )
@@ -190,7 +214,10 @@ config["providers"]["databricks-claude"] = {
     # models docs), so the 128K default badly under-uses it. Set the real window.
     # NB: the FMAPI *rate* limits are separate (e.g. ~200k input tokens/minute on
     # the default tier) — that's throughput, not context, and is not fixed here.
-    "models": [{"id": active_model, "contextWindow": 1000000}],
+    "models": [
+        {"id": model, "contextWindow": 1000000}
+        for model in model_picker
+    ],
 }
 
 models_path.write_text(json.dumps(config, indent=2))

--- a/tests/test_setup_pi.py
+++ b/tests/test_setup_pi.py
@@ -71,7 +71,15 @@ class TestSetupPiConfig:
         assert provider["apiKey"].endswith("anthropic-token-helper.py")
         assert provider["baseUrl"].endswith("/serving-endpoints/anthropic")
         assert provider["compat"] == {"supportsEagerToolInputStreaming": False}
-        assert provider["models"] == [{"id": "databricks-claude-opus-4-8", "contextWindow": 1000000}]
+        assert [m["id"] for m in provider["models"]] == [
+            "databricks-claude-opus-4-8",
+            "databricks-claude-haiku-4-5",
+            "databricks-claude-opus-4-7",
+            "databricks-claude-opus-4-6",
+            "databricks-claude-sonnet-4-6",
+            "databricks-claude-sonnet-4-5",
+        ]
+        assert all(m["contextWindow"] == 1000000 for m in provider["models"])
 
     def test_models_json_is_chmod_600(self, tmp_path):
         _seed_fake_pi_binary(tmp_path)

--- a/tests/test_verify_coda_live.py
+++ b/tests/test_verify_coda_live.py
@@ -156,7 +156,7 @@ class TestFailureAggregation:
                     "cli_display_exact_match": True,
                 },
             },
-            "inference": {"claude": {"ok": True}, "pi": {"ok": True}, "opencode": {"ok": True}},
+            "inference": {"claude": {"ok": True}, "pi": {"ok": True}, "pi_switch": {"ok": True}, "opencode": {"ok": True}},
             "github": {"ok": True},
             "workspace_round_trip": {"ok": True},
         }
@@ -173,6 +173,7 @@ class TestFailureAggregation:
             (lambda r: r["model_catalogs"]["claude"].update(exact_match=False), "claude model catalog does not exactly match READY compatible endpoints"),
             (lambda r: r["model_catalogs"]["pi"].update(exact_match=False), "pi model catalog does not exactly match READY compatible endpoints"),
             (lambda r: r["model_catalogs"]["opencode"].update(cli_display_exact_match=False), "OpenCode displayed model list does not exactly match READY compatible endpoints"),
+            (lambda r: r["inference"]["pi_switch"].update(ok=False), "Pi model switch smoke failed"),
             (lambda r: r["inference"]["opencode"].update(ok=False), "opencode inference smoke failed"),
             (lambda r: r["github"].update(ok=False), "GitHub CLI/repository read smoke failed"),
             (lambda r: r["workspace_round_trip"].update(ok=False), "Databricks workspace write/read/delete round-trip failed"),


### PR DESCRIPTION
Live verification showed Pi could infer with its default Opus model but  contained only , so switching to Sonnet failed. OpenCode successfully switched between Opus and Haiku.

Keep the compatible Claude candidate picker in Pi setup, filter to READY endpoints when discovery is available, and preserve the candidate fallback when discovery is unavailable. The verifier now runs a second configured Pi model marker call so a default-only config cannot pass as a functioning picker.

Local verification: 588 tests pass, including 33 focused setup/verifier tests.