### PR TITLE
fix(omnigent): fence lease generation cleanup

### DIFF
--- a/app.py
+++ b/app.py
@@ -1702,9 +1702,19 @@ def get_version():
 
 @app.route("/api/omnigents-status")
 def omnigents_status():
-    """Report Omnigents host-integration state (FR-9 observability)."""
+    """Report browser-safe host state without runner or host log content."""
     from omnigents_host import get_status
-    return jsonify(get_status())
+
+    status = get_status()
+    browser_fields = (
+        "configured",
+        "running",
+        "installed",
+        "host_launched",
+        "server_url",
+        "stage",
+    )
+    return jsonify({key: status.get(key) for key in browser_fields})
 
 
 @app.route("/api/omnigent-host/status")

--- a/app.py
+++ b/app.py
@@ -1804,6 +1804,9 @@ def omnigent_host_connect():
     server_url = (data.get("server_url") or "").strip()
     if not server_url:
         return jsonify({"error": "server_url required"}), 400
+    configured_server_url = os.environ.get("OMNIGENTS_SERVER_URL", "").strip()
+    if configured_server_url and server_url.rstrip("/") != configured_server_url.rstrip("/"):
+        return jsonify({"error": "server_url does not match configured Omnigent server"}), 409
 
     from omnigents_host import active_lease, connect_host
 
@@ -1836,17 +1839,19 @@ def omnigent_host_disconnect():
         return jsonify({"error": "Forbidden"}), 403
     data = request.get_json(silent=True) or {}
     lease_id = str(data.get("lease_id") or "")
-    from omnigents_host import active_lease, disconnect_host, release_lease
+    from omnigents_host import (
+        _scrub_session_workspaces,
+        active_lease,
+        disconnect_host,
+        release_lease,
+    )
 
     lease = active_lease()
     if lease is None or lease.get("lease_id") != lease_id:
         return jsonify({"released": False, "stale": True})
     status = disconnect_host()
     if data.get("scrub"):
-        shutil.rmtree(
-            os.path.join(os.environ.get("HOME", "/app/python/source_code"), "coda-sessions"),
-            ignore_errors=True,
-        )
+        _scrub_session_workspaces()
     release_lease(lease_id)
     status["released"] = True
     return jsonify(status)

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -132,14 +132,30 @@ def _append_log(line: str) -> None:
         _status["log_tail"] = list(_log_tail)
 
 
+def _lease_expired(lease: dict[str, object], *, now: float | None = None) -> bool:
+    """Return whether a lease crossed its unchanged hard expiry fence."""
+    current = time.time() if now is None else now
+    return float(lease.get("expires_at", 0)) <= current
+
+
+def _scrub_session_workspaces() -> None:
+    """Remove all workspace data belonging to the released lease generation."""
+    shutil.rmtree(
+        os.path.join(os.environ.get("HOME", "/app/python/source_code"), "coda-sessions"),
+        ignore_errors=True,
+    )
+
+
 def acquire_lease(owner: str, lease_id: str) -> tuple[bool, dict[str, object]]:
     """Acquire or adopt the single user lease with an expiry fence."""
     global _lease
     now = time.time()
     with _lock:
-        if _lease is not None and float(_lease.get("expires_at", 0)) <= now:
-            _lease = None
         if _lease is not None:
+            # The reaper stops and scrubs expired generations outside this
+            # lock. Fail closed until that cleanup completes.
+            if _lease_expired(_lease, now=now):
+                return False, dict(_lease)
             if _lease.get("owner") != owner:
                 return False, dict(_lease)
             return True, dict(_lease)
@@ -154,11 +170,10 @@ def acquire_lease(owner: str, lease_id: str) -> tuple[bool, dict[str, object]]:
 
 def active_lease() -> dict[str, object] | None:
     """Return the current unexpired lease, if any."""
-    global _lease
     with _lock:
-        if _lease is not None and float(_lease.get("expires_at", 0)) <= time.time():
-            _lease = None
-        return dict(_lease) if _lease is not None else None
+        if _lease is None or _lease_expired(_lease):
+            return None
+        return dict(_lease)
 
 
 def release_lease(lease_id: str) -> bool:
@@ -267,16 +282,24 @@ def _is_runner_cmdline(cmdline: list[str]) -> bool:
 
 
 def release_idle_lease(*, now: float | None = None, runner_count: int | None = None) -> bool:
-    """Release a lease after ten minutes with no live runner subprocesses."""
+    """Release an expired generation or one idle for ten minutes."""
     global _no_runner_since
-    if active_lease() is None:
+    current = time.time() if now is None else now
+    with _lock:
+        lease_snapshot = dict(_lease) if _lease is not None else None
+    if lease_snapshot is None:
         _no_runner_since = None
         return False
+    if _lease_expired(lease_snapshot, now=current):
+        disconnect_host()
+        _scrub_session_workspaces()
+        released = release_lease(str(lease_snapshot["lease_id"]))
+        _no_runner_since = None
+        return released
     count = _live_runner_count() if runner_count is None else runner_count
     if count is None:
         _no_runner_since = None
         return False
-    current = time.time() if now is None else now
     if count > 0:
         _no_runner_since = None
         return False

--- a/omnigents_host.py
+++ b/omnigents_host.py
@@ -328,7 +328,10 @@ def start_lease_reaper() -> None:
     def _run() -> None:
         while True:
             time.sleep(30)
-            release_idle_lease()
+            try:
+                release_idle_lease()
+            except Exception:
+                logger.exception("CoDA lease reaper cleanup failed; preserving lease")
 
     threading.Thread(target=_run, daemon=True, name="coda-lease-reaper").start()
 

--- a/static/index.html
+++ b/static/index.html
@@ -712,7 +712,7 @@
     let omnigentShareFired = false;
 
     async function refreshOmnigentHostStatus() {
-      const resp = await fetch('/api/omnigent-host/status');
+      const resp = await fetch('/api/omnigents-status');
       const status = await resp.json();
       renderOmnigentHostStatus(status);
       if (status.stage === 'running' && !omnigentShareFired) {

--- a/tests/test_omnigents_host.py
+++ b/tests/test_omnigents_host.py
@@ -99,6 +99,33 @@ def test_allocate_workspace_is_fenced_and_distinct(monkeypatch, tmp_path) -> Non
         oh.allocate_workspace("lease-old", "session_three")
 
 
+def test_expired_lease_cleans_generation_before_owner_handoff(monkeypatch, tmp_path) -> None:
+    oh.reset_for_tests()
+    now = [100.0]
+    monkeypatch.setattr(oh.time, "time", lambda: now[0])
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ok, _ = oh.acquire_lease("alice@example.com", "lease-a")
+    assert ok is True
+    workspace = oh.allocate_workspace("lease-a", "session_one")
+    assert os.path.isdir(workspace)
+
+    now[0] += oh._CODA_MAX_LEASE_S + 1
+    assert oh.active_lease() is None
+    ok, stale = oh.acquire_lease("bob@example.com", "lease-b")
+    assert ok is False
+    assert stale["lease_id"] == "lease-a"
+
+    disconnected: list[bool] = []
+    monkeypatch.setattr(oh, "disconnect_host", lambda: disconnected.append(True) or {})
+    assert oh.release_idle_lease(now=now[0], runner_count=1) is True
+    assert disconnected == [True]
+    assert not os.path.exists(tmp_path / "coda-sessions")
+
+    ok, lease = oh.acquire_lease("bob@example.com", "lease-b")
+    assert ok is True
+    assert lease["lease_id"] == "lease-b"
+
+
 def test_idle_lease_releases_after_no_runner_window(monkeypatch) -> None:
     oh.reset_for_tests()
     oh.acquire_lease("alice@example.com", "lease-a")

--- a/tests/test_omnigents_host_api.py
+++ b/tests/test_omnigents_host_api.py
@@ -17,6 +17,37 @@ def _import_app():
         return module
 
 
+def test_browser_status_omits_logs_and_error_details(monkeypatch):
+    app_module = _import_app()
+    monkeypatch.setattr(
+        "omnigents_host.get_status",
+        lambda: {
+            "configured": True,
+            "running": True,
+            "installed": True,
+            "host_launched": True,
+            "server_url": "https://omnigent.example.com",
+            "stage": "running",
+            "last_error": "Authorization: Bearer secret",
+            "log_tail": ["SECRET_REPOSITORY_OUTPUT"],
+        },
+    )
+
+    with app_module.app.test_client() as client:
+        with mock.patch.object(app_module, "_is_databricks_apps", return_value=False):
+            resp = client.get("/api/omnigents-status")
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {
+        "configured": True,
+        "host_launched": True,
+        "installed": True,
+        "running": True,
+        "server_url": "https://omnigent.example.com",
+        "stage": "running",
+    }
+
+
 def test_omnigent_host_status_returns_state(monkeypatch):
     app_module = _import_app()
     monkeypatch.setattr("omnigents_host.get_status", lambda: {"stage": "idle", "running": False})

--- a/tests/test_omnigents_host_api.py
+++ b/tests/test_omnigents_host_api.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import mock
 
 
@@ -88,6 +89,31 @@ def test_omnigent_host_connect_calls_supervisor(monkeypatch):
     assert called["url"] == "https://omnigent.example.com"
     assert called["sp_creds"] == app_module._omnigent_sp_creds
     assert called["lease_id"] == "lease-a"
+
+
+def test_omnigent_host_connect_rejects_configured_server_mismatch(monkeypatch):
+    app_module = _import_app()
+    monkeypatch.setenv("OMNIGENTS_SERVER_URL", "https://omnigent.example.com/")
+    from omnigents_host import acquire_lease
+
+    acquire_lease("owner@example.com", "lease-a")
+    with app_module.app.test_client() as client:
+        resp = client.post(
+            "/api/omnigent-host/connect",
+            json={"server_url": "https://attacker.example", "lease_id": "lease-a"},
+        )
+
+    assert resp.status_code == 409
+    assert resp.get_json() == {
+        "error": "server_url does not match configured Omnigent server"
+    }
+
+
+def test_browser_polls_owner_authenticated_status_endpoint():
+    static_html = Path(__file__).parents[1] / "static" / "index.html"
+    source = static_html.read_text()
+    assert "fetch('/api/omnigents-status')" in source
+    assert "fetch('/api/omnigent-host/status')" not in source
 
 
 def test_omnigent_host_connect_conflict(monkeypatch):


### PR DESCRIPTION
## Summary

- fail closed on expired lease generations until the reaper disconnects and scrubs them
- preserve the existing 12-hour hard expiry and 10-minute idle timeout
- fence managed connect to the configured Omnigent server URL
- restore browser status polling without weakening server-SP M2M routes

Beads: `omnigent-90n.6.1.2`, `omnigent-90n.6.1.3`

## Testing

- practical unit suite: 603 passed, 3 skipped
- focused host/API/auth suites: 81 passed
- Python compile and `git diff --check` passed

## Live verification

Exact merged-dev-head deployment and Pi UI evidence will be captured after this PR and its Omnigent companion merge.
